### PR TITLE
Add another state listener to the Slack notification

### DIFF
--- a/docs/01-basics.md
+++ b/docs/01-basics.md
@@ -26,7 +26,7 @@ Whenever you have a key, you will need to export it like so:
 $ export PREFECT__CLOUD__API_KEY="<YOUR-KEY>"
 ```
 
-If you will be using agents, you may want to run this command:
+If you will be using agents, you may instead want to run this command:
 
 ```shell
 $ prefect auth login --key <YOUR-KEY>
@@ -113,7 +113,7 @@ The next step is to actually run the flow. For this,
 we are going to use an existing flow:
 
 ```bash
-$ python flow/test/test.py
+$ python flows/test/test.py
 ```
 
 ## Environments
@@ -136,14 +136,14 @@ you have the option to register the flow directly
 from your machine, or you can let the GitHub Actions
 do it for you.
 
-What happens when you register a flow? From Prefect, we can read:
+What happens when you register a flow? From Prefect, we read:
 
 > When you register a Flow, your code is securely stored on your infrastructure — your code never leaves your execution environment and is never sent to Prefect Cloud. Instead, Flow metadata is sent to Prefect Cloud for scheduling and orchestration.
 
 To let GH actions register the file just merge
 your file into the github main branch. For specific
 details about how to work the branches and PRs world
-go to the DevOps section of this documentation.
+go to the DevOps section (page no. 10) of this documentation.
 
 To register the flow yourself, there is the `prefect register` command:
 

--- a/docs/03-python-shell-docker.md
+++ b/docs/03-python-shell-docker.md
@@ -27,7 +27,7 @@ shell_task = ShellTask(
 
 ## Python
 
-Running python is not as different, we use 
+Running python is not that different, we use 
 the same ShellTask class and we mix it up:
 
 ```python

--- a/docs/07-debugging.md
+++ b/docs/07-debugging.md
@@ -110,7 +110,7 @@ raise failed_state.result
 Example:
 
 ```python
-rom prefect import Flow, task
+from prefect import Flow, task
 
 
 @task

--- a/flows/MDS/bird.py
+++ b/flows/MDS/bird.py
@@ -17,7 +17,7 @@ from datetime import datetime, timedelta
 from prefect import Flow, task
 from prefect.storage import GitHub
 from prefect.run_configs import UniversalRun
-from prefect.engine.state import Failed
+from prefect.engine.state import Failed, TriggerFailed
 from prefect.schedules import Schedule
 from prefect.schedules.clocks import CronClock
 from prefect.backend import get_key_value
@@ -29,9 +29,8 @@ from prefect.utilities.notifications import slack_notifier
 current_environment = os.getenv("PREFECT_CURRENT_ENVIRONMENT", "staging")
 
 # Set up slack fail handler
-handler = slack_notifier(only_states=[Failed])
+handler = slack_notifier(only_states=[Failed, TriggerFailed])
 
-# Notice how test_kv is an object that contains our data as a dictionary:
 mds_provider = "bird"
 docker_image = f"atddocker/atd-mds-etl:{current_environment}"
 environment_variables = get_key_value(key=f"atd_mds_config_{current_environment}")
@@ -115,7 +114,6 @@ def provider_sync_socrata():
 
 
 # Next, we define the flow (equivalent to a DAG).
-# Notice we use the label "test" to match this flow to an agent.
 with Flow(
     # Postfix the name of the flow with the environment it belongs to
     f"atd_mds_{mds_provider}_{current_environment}",

--- a/flows/MDS/link.py
+++ b/flows/MDS/link.py
@@ -17,7 +17,7 @@ from datetime import datetime, timedelta
 from prefect import Flow, task
 from prefect.storage import GitHub
 from prefect.run_configs import UniversalRun
-from prefect.engine.state import Failed
+from prefect.engine.state import Failed, TriggerFailed
 from prefect.schedules import Schedule
 from prefect.schedules.clocks import CronClock
 from prefect.backend import get_key_value
@@ -29,7 +29,7 @@ from prefect.utilities.notifications import slack_notifier
 current_environment = os.getenv("PREFECT_CURRENT_ENVIRONMENT", "staging")
 
 # Set up slack fail handler
-handler = slack_notifier(only_states=[Failed])
+handler = slack_notifier(only_states=[Failed, TriggerFailed])
 
 # Notice how test_kv is an object that contains our data as a dictionary:
 mds_provider = "link"


### PR DESCRIPTION
We have some flows failing, but the failures aren't being reported to Slack. I want to try adding another state to listen for to see if it will show up in slack. 

https://docs.prefect.io/api/latest/engine/state.html#triggerfailed