### PR TITLE
Use correct github ref for knack banner flow

### DIFF
--- a/flows/knack/knack_banner.py
+++ b/flows/knack/knack_banner.py
@@ -97,7 +97,7 @@ with Flow(
     storage=GitHub(
         repo="cityofaustin/atd-prefect",
         path="flows/knack/knack_banner.py",
-        ref=current_environment.replace("staging", "main")
+        ref="main"
     ),
     run_config=UniversalRun(labels=[current_environment, "atd-data02"]),
     result=PrefectResult(),
@@ -110,8 +110,8 @@ with Flow(
     f"send_hr_email_{current_environment}",
     storage=GitHub(
         repo="cityofaustin/atd-prefect",
-        path="flows/test/knack_banner.py",
-        ref=current_environment.replace("staging", "main"),  # The branch name
+        path="flows/knack/knack_banner.py",
+        ref="main"  # The branch name
     ),
     run_config=UniversalRun(labels=["test", "atd-data02"]),
 ) as send_email_flow:


### PR DESCRIPTION
The flow was erroring immediately because it was looking for the file in github in the production branch, based on the current_environment. I am changing the ref to be main, regardless of environment file. 

I'm also correcting a mistake that Mateo pointed out when he reviewed this file earlier, that I neglected to fix. 