### PR TITLE
Finance Production was failing

### DIFF
--- a/flows/moped/finance_data.py
+++ b/flows/moped/finance_data.py
@@ -95,7 +95,7 @@ with Flow(
     ),
     # Run config will always need the current_environment
     # plus whatever labels you need to attach to this flow
-    run_config=UniversalRun(labels=["test", "atd-data02"]),
+    run_config=UniversalRun(labels=[current_environment, "atd-data02"]),
     schedule=Schedule(clocks=[CronClock("30 12 * * *")]),
 ) as flow:
     flow.chain(pull_docker_image, s3_to_socrata)


### PR DESCRIPTION
This flow was still looking for `atd_finance_staging` because I was tagging this with `test`. Changed to be `current_environment`. 

If I understand this correctly, that the `atd-data02` production agent will have an environment variable called  PREFECT_CURRENT_ENVIRONMENT and this will work? That seems to be the pattern that we've implemented so far.

```
current_environment = os.getenv("PREFECT_CURRENT_ENVIRONMENT", "staging")
```