### PR TITLE
fix mislabeled agent - knack banner

### DIFF
--- a/flows/knack/knack_banner.py
+++ b/flows/knack/knack_banner.py
@@ -113,7 +113,7 @@ with Flow(
         path="flows/knack/knack_banner.py",
         ref="main"  # The branch name
     ),
-    run_config=UniversalRun(labels=["test", "atd-data02"]),
+    run_config=UniversalRun(labels=[current_environment, "atd-data02"]),
 ) as send_email_flow:
     get_data_flow_run_id = create_flow_run(flow_name=get_data_flow.name)
     script_result = get_task_run_result(


### PR DESCRIPTION
Once again I'm asking for review on my flows

After manually registering the flows, I got one to run successfully. When I checked why the second one didnt run, i realized it was tagged to the wrong agent. 