### PR TITLE
Update actions so that Prefect 1.0 is installed

### DIFF
--- a/.github/workflows/register_flows.yml
+++ b/.github/workflows/register_flows.yml
@@ -38,7 +38,7 @@ jobs:
       - name: "Installing Prefect"
         run: |
           sudo apt-get install -y python3-setuptools
-          pip3 install awscli boto3 virtualenv requests prefect
+          pip3 install awscli boto3 virtualenv requests "prefect==1.*"
       # Run the shell commands using the AWS environment variables
       - name: "Register Flows"
         env:


### PR DESCRIPTION
@chiaberry warned us on slack earlier that:
>With next week’s release on July 27th, Prefect 2.0 will become the default package installed when you execute `pip install prefect`. Please ensure that your package management process enables you to make the transition to Prefect 2.0 when the time is right for you.
:rotating_light: Note: Flows written with Prefect 1.0 will require modifications to run with Prefect 2.0

Our github action that registers our flows now fails, presumably because it is defaulting to Prefect 2.0. This change will make sure we install 1.X

[Slack convo](https://austininnovation.slack.com/archives/CHZE6BC6L/p1659455074941139)

***

@johnclary also pointed out that we should probably be pinning the version numbers of `boto3` `virtualenv` and `requests`.

Looking at our [requirements.txt](https://github.com/cityofaustin/atd-prefect/blob/main/requirements.txt), we're installing: `requests==2.26.0` but nothing showing for boto3 and virtualenv. Maybe someone could log-in to `data03` to see what version we're running so we can pin them?