### PR TITLE
Prefect-ifying ATD Knack Services

### DIFF
--- a/flows/knack/README.md
+++ b/flows/knack/README.md
@@ -1,0 +1,36 @@
+## knack_services.py
+
+This flow uses the docker image automatically created by [this repo](https://github.com/cityofaustin/atd-knack-services). When it is run, it will pull the latest docker image and then run a series of commands inside that container.
+
+***
+
+Primary tasks:
+- pull_docker_image: pretty straightforward, pulls the latest docker image for `atd-knack-services`
+- get_last_exec_time: Uses Prefect's key value storage to get the last date this flow was run, and passes this value onto all downstream tasks. If it is on the 15th of a month, all data will automatically get replaced. If the `Replace all Data` parameter is set to `True` then it will replace all data.
+- records_to_postgrest: Downloads knack records and sends them to a postgres DB
+- records_to_agol: (optional) Sends data from postgrest to AGOL
+- records_to_socrata: (optional) Sends data from postgrest to Socrata
+- agol_build_markings_segment_geometries: (optional) For markings work orders, builds geometry in AGOL based on provided street segments
+- records_to_knack: (optional) Send data from one knack app to a destination knack app
+- update_last_exec_time: If all upstream tasks were successful, update the date for last execution value storage in Prefect with the current date
+
+***
+
+Parameters:
+- App Name (str): The name of the source knack app (ex: "data-tracker")
+- Knack Container (str): The "view" name of the container in knack (ex: "view_3628")
+- Records to Knack: App Name Destination (str): If provided, will send data from the source knack app to the destination knack app in `records_to_knack`. Providing an empty string will skip this task.
+- AGOL Build Segment Geometry Layer (str): The name of the layer in the `CONFIG` of `agol_build_markings_segment_geometries.py` to build the geometry of. Providing an empty string will skip this task.
+- Replace all Data (bool): A flag if True to replace all data and ignore typical modified date constraints 
+- Send data to Socrata (bool): A flag if True to send data to the provided Socrata dataset
+- Send data to AGOL (bool): A flag if True to send data to the provided AGOL layer
+
+***
+
+## Configuring a Knack Services flow in the Prefect UI
+
+1. Head to the [flow's page](https://cloud.prefect.io/dts/flow/d6b44480-d8e8-4367-b3f8-b760fbd4a2c3?overview) in the Prefect UI and authenticate if you need to.
+2. Go to settings -> schedule -> new schedule
+3. Configure your schedule settings or provide a cron string by using the "advanced slider"
+4. Go to the parameters tab, **check the boxes on the left to overwrite the default values**, and provide the necessary parameters to run your flow, then click create.
+5. Go back to the overview tab to observe if your flow is scheduled correctly, this may take a few minutes to refresh.

--- a/flows/knack/knack_services.py
+++ b/flows/knack/knack_services.py
@@ -52,7 +52,7 @@ docker_env = "production"
 docker_image = f"atddocker/atd-knack-services:{docker_env}"
 
 # Based on inputs, determine if some conditional tasks should run
-@task(name="determine_task_runs")
+@task(name="determine_task_runs", nout=2)
 def determine_task_runs(layer, app_name_dest):
     return bool(layer), bool(app_name_dest)
 

--- a/flows/knack/knack_services.py
+++ b/flows/knack/knack_services.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python
+
+"""
+Name: Parking Data Reconciliation Flows
+Description: Parse Fiserv emails then upsert the CSVs to a postgres DB.
+    Grab the payment data retrived from flowbird and upsert that to a postgres DB.
+    Then, compare them before uploading the data to Socrata.
+Schedule: "30 5 * * *"
+Labels: atd-data02, parking
+"""
+
+import os
+
+import docker
+import prefect
+from datetime import datetime, timedelta
+
+# Prefect
+from prefect import Flow, task
+from prefect.storage import GitHub
+from prefect.run_configs import UniversalRun
+from prefect.engine.state import Failed
+from prefect.schedules import Schedule
+from prefect.schedules.clocks import CronClock
+from prefect.backend import set_key_value, get_key_value
+from prefect.triggers import all_successful
+from prefect.tasks.docker import PullImage
+
+
+from prefect.utilities.notifications import slack_notifier
+
+# Define current environment
+current_environment = "test"
+
+# Set up slack fail handler
+handler = slack_notifier(only_states=[Failed])
+
+# Logger instance
+logger = prefect.context.get("logger")
+
+# Select the appropriate tag for the Docker Image
+docker_env = "test"
+docker_image = f"atddocker/atd-knack-services:{docker_env}"
+
+environment_variables = get_key_value(key=f"atd_parking_data_meters")
+
+# Last execution date
+# prev_execution_key = f"parking_data_reconciliation_prev_exec"
+# prev_execution_date_success = get_key_value(prev_execution_key)
+
+# Task to pull the latest Docker image
+# @task(
+#    name="pull_docker_image",
+#    max_retries=1,
+#    timeout=timedelta(minutes=60),
+#    retry_delay=timedelta(minutes=5),
+#    state_handlers=[handler],
+#    log_stdout=True
+# )
+# def pull_docker_image():
+#    client = docker.from_env()
+#    client.images.pull("atddocker/atd-parking-data-meters", all_tags=True)
+#    logger.info(docker_env)
+#    return
+
+
+# Records to postgrest
+@task(
+    name="records_to_postgrest",
+    max_retries=1,
+    timeout=timedelta(minutes=60),
+    retry_delay=timedelta(minutes=5),
+    # state_handlers=[handler],
+    log_stdout=True,
+)
+def records_to_postgrest():
+    response = (
+        docker.from_env()
+        .containers.run(
+            image=docker_image,
+            working_dir=None,
+            command="python app/services/records_to_postgrest.py -a signs-markings -c view_3628",
+            environment=environment_variables,
+            volumes=None,
+            remove=True,
+            detach=False,
+            stdout=True,
+        )
+        .decode("utf-8")
+    )
+    logger.info(response)
+    return response
+
+
+# @task(trigger=all_successful)
+# def update_last_exec_time():
+#    new_date = datetime.today().strftime("%Y-%m-%d")
+#    set_key_value(key=prev_execution_key, value=new_date)
+
+
+# Next, we define the flow (equivalent to a DAG).
+# Notice we use the label "test" to match this flow to an agent.
+with Flow(
+    # Postfix the name of the flow with the environment it belongs to
+    f"knack_services_{current_environment}",
+    # Let's configure the agents to download the file from this repo
+    storage=GitHub(
+        repo="cityofaustin/atd-prefect",
+        path="flows/knack/knack_services.py",
+        ref="atd-knack-services",  # The branch name
+    ),
+    # Run config will always need the current_environment
+    # plus whatever labels you need to attach to this flow
+    run_config=UniversalRun(labels=["local", "charliesmacbook"]),
+    schedule=None,
+) as flow:
+    flow.chain(
+        records_to_postgrest,
+    )
+
+
+if __name__ == "__main__":
+    flow.run()

--- a/flows/knack/knack_services.py
+++ b/flows/knack/knack_services.py
@@ -222,24 +222,22 @@ def records_to_socrata(app_name, container, date_filter, environment_variables):
     log_stdout=True,
 )
 def agol_build_markings_segment_geometries(layer, date_filter, environment_variables):
-    if layer:
-        response = (
-            docker.from_env()
-            .containers.run(
-                image=docker_image,
-                working_dir=None,
-                command=f"python atd-knack-services/services/agol_build_markings_segment_geometries.py -l {layer} -d {date_filter}",
-                environment=environment_variables,
-                volumes=None,
-                remove=True,
-                detach=False,
-                stdout=True,
-            )
-            .decode("utf-8")
+    response = (
+        docker.from_env()
+        .containers.run(
+            image=docker_image,
+            working_dir=None,
+            command=f"python atd-knack-services/services/agol_build_markings_segment_geometries.py -l {layer} -d {date_filter}",
+            environment=environment_variables,
+            volumes=None,
+            remove=True,
+            detach=False,
+            stdout=True,
         )
-        logger.info(response)
-        return response
-    return
+        .decode("utf-8")
+    )
+    logger.info(response)
+    return response
 
 
 # Send Records to a destination knack app

--- a/flows/knack/knack_services.py
+++ b/flows/knack/knack_services.py
@@ -42,7 +42,7 @@ logger = prefect.context.get("logger")
 docker_env = "test"
 docker_image = f"atddocker/atd-knack-services:{docker_env}"
 
-environment_variables = get_key_value(key=f"atd_parking_data_meters")
+environment_variables = get_key_value(key=f"atd_knack_services")
 
 # Last execution date
 # prev_execution_key = f"parking_data_reconciliation_prev_exec"

--- a/flows/knack/knack_services.py
+++ b/flows/knack/knack_services.py
@@ -37,7 +37,10 @@ LAYER_NAME = "markings_contractor_work_orders"
 # Parameter that will overwrite all data (ignores date)
 REPLACE_DATA = False
 APP_NAME_DEST = ""
+# Options to run tasks
 TO_KNACK = False
+BUILD_GEOM = False
+
 
 # Define current environment
 current_environment = "prod"
@@ -305,6 +308,7 @@ with Flow(
     replace_data = Parameter("replace_data", default=REPLACE_DATA, required=True)
     app_name_dest = Parameter("app_name_dest", default=APP_NAME_DEST, required=False)
     to_knack = Parameter("to_knack", default=False, required=True)
+    build_geom = Parameter("build_geom", default=False, required=True)
 
     # Get the last time the flow ran for this app/container combo
     date_filter = get_last_exec_time(app_name, container, replace_data)
@@ -338,7 +342,7 @@ with Flow(
         upstream_tasks=[docker_pull, postgrest_res],
     )
     # 5. Build line geometries in AGOL (optional)
-    with case(bool(layer), True):
+    with case(build_geom, True):
         agol_build_res = agol_build_markings_segment_geometries(
             layer,
             date_filter,
@@ -368,5 +372,6 @@ if __name__ == "__main__":
             "replace_data": REPLACE_DATA,
             "app_name_dest": APP_NAME_DEST,
             "to_knack": TO_KNACK,
+            "build_geom": BUILD_GEOM,
         }
     )

--- a/flows/knack/knack_services.py
+++ b/flows/knack/knack_services.py
@@ -36,7 +36,8 @@ CONTAINER = "view_3628"
 LAYER_NAME = "markings_contractor_work_orders"
 # Parameter that will overwrite all data (ignores date)
 REPLACE_DATA = False
-APP_NAME_DEST = None
+APP_NAME_DEST = ""
+TO_KNACK = False
 
 # Define current environment
 current_environment = "prod"
@@ -303,6 +304,7 @@ with Flow(
     layer = Parameter("layers", default=LAYER_NAME, required=False)
     replace_data = Parameter("replace_data", default=REPLACE_DATA, required=True)
     app_name_dest = Parameter("app_name_dest", default=APP_NAME_DEST, required=False)
+    to_knack = Parameter("to_knack", default=False, required=True)
 
     # Get the last time the flow ran for this app/container combo
     date_filter = get_last_exec_time(app_name, container, replace_data)
@@ -344,7 +346,7 @@ with Flow(
             upstream_tasks=[docker_pull, agol_res],
         )
     # 6. Send data to another knack app (optional)
-    with case(bool(app_name_dest), True):
+    with case(to_knack, True):
         knack_res = records_to_knack(
             app_name,
             container,
@@ -365,5 +367,6 @@ if __name__ == "__main__":
             "layers": LAYER_NAME,
             "replace_data": REPLACE_DATA,
             "app_name_dest": APP_NAME_DEST,
+            "to_knack": TO_KNACK,
         }
     )

--- a/flows/knack/knack_services.py
+++ b/flows/knack/knack_services.py
@@ -111,7 +111,7 @@ with Flow(
     ),
     # Run config will always need the current_environment
     # plus whatever labels you need to attach to this flow
-    run_config=UniversalRun(labels=["local", "charliesmacbook"]),
+    run_config=LocalRun(labels=["local", "charliesmacbook"]),
     schedule=None,
 ) as flow:
     flow.chain(

--- a/flows/knack/knack_services.py
+++ b/flows/knack/knack_services.py
@@ -18,7 +18,7 @@ from datetime import datetime, timedelta
 # Prefect
 from prefect import Flow, task
 from prefect.storage import GitHub
-from prefect.run_configs import UniversalRun
+from prefect.run_configs import LocalRun
 from prefect.engine.state import Failed
 from prefect.schedules import Schedule
 from prefect.schedules.clocks import CronClock

--- a/flows/knack/knack_services.py
+++ b/flows/knack/knack_services.py
@@ -56,7 +56,7 @@ logger = prefect.context.get("logger")
 docker_env = "test"
 docker_image = f"atddocker/atd-knack-services:{docker_env}"
 
-environment_variables = get_key_value(key=f"atd_knack_services")
+environment_variables = get_key_value(key=f"signs-markings-atd_knack_services")
 
 # Last execution date
 # prev_execution_key = f"parking_data_reconciliation_prev_exec"
@@ -190,10 +190,10 @@ def agol_build_markings_segment_geometries(layer):
     return response
 
 
-# @task(trigger=all_successful)
-# def update_last_exec_time():
-#    new_date = datetime.today().strftime("%Y-%m-%d")
-#    set_key_value(key=prev_execution_key, value=new_date)
+@task(trigger=all_successful)
+def update_last_exec_time():
+    new_date = datetime.today().strftime("%Y-%m-%d")
+    set_key_value(key=prev_execution_key, value=new_date)
 
 
 # Next, we define the flow (equivalent to a DAG).

--- a/flows/knack/knack_services.py
+++ b/flows/knack/knack_services.py
@@ -78,6 +78,7 @@ def pull_docker_image():
 # Get the envrioment variables for the given app
 @task(
     name="get_env_vars",
+    task_run_name="get_env_vars:{app}",
     max_retries=1,
     timeout=timedelta(minutes=60),
     retry_delay=timedelta(minutes=5),
@@ -92,6 +93,7 @@ def get_env_vars(app):
 # Get the last date (string) the flow was succesful
 @task(
     name="get_last_exec_time",
+    task_run_name="get_last_exec_time:{app}-{container}",
     max_retries=1,
     timeout=timedelta(minutes=60),
     retry_delay=timedelta(minutes=5),
@@ -125,6 +127,7 @@ def get_last_exec_time(app, container, replace_data):
 # Records to postgrest
 @task(
     name="records_to_postgrest",
+    task_run_name="records_to_postgrest:{app_name}-{container}-{date_filter}",
     max_retries=1,
     timeout=timedelta(minutes=60),
     retry_delay=timedelta(minutes=5),
@@ -153,6 +156,7 @@ def records_to_postgrest(app_name, container, date_filter, environment_variables
 # Records to AGOL
 @task(
     name="records_to_agol",
+    task_run_name="records_to_agol:{app_name}-{container}-{date_filter}",
     max_retries=1,
     timeout=timedelta(minutes=60),
     retry_delay=timedelta(minutes=5),
@@ -181,6 +185,7 @@ def records_to_agol(app_name, container, date_filter, environment_variables):
 # Records to Socrata
 @task(
     name="records_to_socrata",
+    task_run_name="records_to_socrata:{app_name}-{container}-{date_filter}",
     max_retries=1,
     timeout=timedelta(minutes=60),
     retry_delay=timedelta(minutes=5),
@@ -209,6 +214,7 @@ def records_to_socrata(app_name, container, date_filter, environment_variables):
 # Building AGOL segment geometries
 @task(
     name="agol_build_markings_segment_geometries",
+    task_run_name="agol_build_markings_segment_geometries:{layer}-{date_filter}",
     max_retries=1,
     timeout=timedelta(minutes=60),
     retry_delay=timedelta(minutes=5),

--- a/flows/knack/knack_services.py
+++ b/flows/knack/knack_services.py
@@ -50,16 +50,16 @@ environment_variables = get_key_value(key=f"atd_parking_data_meters")
 
 # Task to pull the latest Docker image
 # @task(
-#    name="pull_docker_image",
-#    max_retries=1,
-#    timeout=timedelta(minutes=60),
-#    retry_delay=timedelta(minutes=5),
-#    state_handlers=[handler],
-#    log_stdout=True
+#   name="pull_docker_image",
+#   max_retries=1,
+#   timeout=timedelta(minutes=60),
+#   retry_delay=timedelta(minutes=5),
+#   state_handlers=[handler],
+#   log_stdout=True
 # )
 # def pull_docker_image():
 #    client = docker.from_env()
-#    client.images.pull("atddocker/atd-parking-data-meters", all_tags=True)
+#    client.images.pull("atddocker/atd-knack-services", all_tags=True)
 #    logger.info(docker_env)
 #    return
 
@@ -79,7 +79,7 @@ def records_to_postgrest():
         .containers.run(
             image=docker_image,
             working_dir=None,
-            command="python app/services/records_to_postgrest.py -a signs-markings -c view_3628",
+            command="python atd-knack-services/services/records_to_postgrest.py -a signs-markings -c view_3628",
             environment=environment_variables,
             volumes=None,
             remove=True,

--- a/flows/knack/knack_services.py
+++ b/flows/knack/knack_services.py
@@ -29,27 +29,16 @@ from prefect.tasks.docker import PullImage
 
 from prefect.utilities.notifications import slack_notifier
 
-# CONFIG = [
-#    {
-#        "apps": "signs-markings",
-#        "containers": "view_3628",
-#        "layer": "markings_contractor_work_orders",
-#    },
-# ]
 
+# Default parameters is for Signs/Markings Contractor Work Orders
+APP_NAME = "signs-markings"
+CONTAINER = "view_3628"
+LAYER_NAME = "markings_contractor_work_orders"
+# Parameter that will overwrite all data (ignores date)
 REPLACE_DATA = False
 
-# Report names and ids separated from dicts
-# app_names = [i["apps"] for i in CONFIG]
-# containers = [i["containers"] for i in CONFIG]
-# layer_names = [i["layer"] for i in CONFIG]
-
-app_name = "signs-markings"
-container = "view_3628"
-layer_name = "markings_contractor_work_orders"
-
 # Define current environment
-current_environment = "test"
+current_environment = "prod"
 
 # Set up slack fail handler
 handler = slack_notifier(only_states=[Failed])
@@ -58,7 +47,7 @@ handler = slack_notifier(only_states=[Failed])
 logger = prefect.context.get("logger")
 
 # Select the appropriate tag for the Docker Image
-docker_env = "test"
+docker_env = "production"
 docker_image = f"atddocker/atd-knack-services:{docker_env}"
 
 
@@ -274,12 +263,12 @@ with Flow(
         path="flows/knack/knack_services.py",
         ref="atd-knack-services",  # The branch name
     ),
-    run_config=LocalRun(labels=["atd-data02", "test"]),
+    run_config=LocalRun(labels=["atd-data02", "production"]),
     schedule=None,
 ) as flow:
-    app_name = Parameter("apps", default=app_name, required=False)
-    container = Parameter("containers", default=container, required=False)
-    layer = Parameter("layers", default=layer_name, required=False)
+    app_name = Parameter("apps", default=APP_NAME, required=False)
+    container = Parameter("containers", default=CONTAINER, required=False)
+    layer = Parameter("layers", default=LAYER_NAME, required=False)
     replace_data = Parameter("replace_data", default=REPLACE_DATA, required=True)
 
     # Get the last time the flow ran for this app/container combo
@@ -307,9 +296,9 @@ with Flow(
 if __name__ == "__main__":
     flow.run(
         parameters={
-            "apps": app_name,
-            "containers": container,
-            "layers": layer_name,
+            "apps": APP_NAME,
+            "containers": CONTAINER,
+            "layers": LAYER_NAME,
             "replace_data": REPLACE_DATA,
         }
     )

--- a/flows/knack/knack_services.py
+++ b/flows/knack/knack_services.py
@@ -49,19 +49,19 @@ environment_variables = get_key_value(key=f"atd_parking_data_meters")
 # prev_execution_date_success = get_key_value(prev_execution_key)
 
 # Task to pull the latest Docker image
-# @task(
-#   name="pull_docker_image",
-#   max_retries=1,
-#   timeout=timedelta(minutes=60),
-#   retry_delay=timedelta(minutes=5),
-#   state_handlers=[handler],
-#   log_stdout=True
-# )
-# def pull_docker_image():
-#    client = docker.from_env()
-#    client.images.pull("atddocker/atd-knack-services", all_tags=True)
-#    logger.info(docker_env)
-#    return
+@task(
+    name="pull_docker_image",
+    max_retries=1,
+    timeout=timedelta(minutes=60),
+    retry_delay=timedelta(minutes=5),
+    state_handlers=[handler],
+    log_stdout=True,
+)
+def pull_docker_image():
+    client = docker.from_env()
+    client.images.pull("atddocker/atd-knack-services", all_tags=True)
+    logger.info(docker_env)
+    return
 
 
 # Records to postgrest
@@ -111,10 +111,11 @@ with Flow(
     ),
     # Run config will always need the current_environment
     # plus whatever labels you need to attach to this flow
-    run_config=LocalRun(labels=["local", "charliesmacbook"]),
+    run_config=LocalRun(labels=["atd-data02", "test"]),
     schedule=None,
 ) as flow:
     flow.chain(
+        pull_docker_image,
         records_to_postgrest,
     )
 

--- a/flows/knack/knack_services.py
+++ b/flows/knack/knack_services.py
@@ -274,7 +274,7 @@ with Flow(
     # Get the last time the flow ran for this app/container combo
     date_filter = get_last_exec_time.map(app_name, container, unmapped(replace_data))
 
-    environment_variables = get_env_vars(app_name)
+    environment_variables = get_env_vars.map(app_name)
 
     flow.chain(
         # 1. Pull latest docker image

--- a/flows/knack/knack_services.py
+++ b/flows/knack/knack_services.py
@@ -93,7 +93,7 @@ def get_env_vars(app):
 # Get the last date (string) the flow was succesful
 @task(
     name="get_last_exec_time",
-    task_run_name="get_last_exec_time (app:{app}, container:{container})",
+    task_run_name="get_last_exec_time (app: {app}, container: {container})",
     max_retries=1,
     timeout=timedelta(minutes=60),
     retry_delay=timedelta(minutes=5),
@@ -156,7 +156,7 @@ def records_to_postgrest(app_name, container, date_filter, environment_variables
 # Records to AGOL
 @task(
     name="records_to_agol",
-    task_run_name="records_to_agol (app:{app_name}, container:{container}, date_filter:{date_filter})",
+    task_run_name="records_to_agol (app: {app_name}, container: {container}, date_filter: {date_filter})",
     max_retries=1,
     timeout=timedelta(minutes=60),
     retry_delay=timedelta(minutes=5),
@@ -185,7 +185,7 @@ def records_to_agol(app_name, container, date_filter, environment_variables):
 # Records to Socrata
 @task(
     name="records_to_socrata",
-    task_run_name="records_to_socrata (app: {app_name}, container:{container}, date_filter:{date_filter})",
+    task_run_name="records_to_socrata (app: {app_name}, container: {container}, date_filter: {date_filter})",
     max_retries=1,
     timeout=timedelta(minutes=60),
     retry_delay=timedelta(minutes=5),
@@ -214,7 +214,7 @@ def records_to_socrata(app_name, container, date_filter, environment_variables):
 # Building AGOL segment geometries
 @task(
     name="agol_build_markings_segment_geometries",
-    task_run_name="agol_build_markings_segment_geometries (layer: {layer}, date_filter:{date_filter})",
+    task_run_name="agol_build_markings_segment_geometries (layer: {layer}, date_filter: {date_filter})",
     max_retries=1,
     timeout=timedelta(minutes=60),
     retry_delay=timedelta(minutes=5),

--- a/flows/knack/knack_services.py
+++ b/flows/knack/knack_services.py
@@ -143,7 +143,7 @@ def records_to_agol(app_name, container):
     # state_handlers=[handler],
     log_stdout=True,
 )
-def records_to_agol(app_name, container):
+def records_to_socrata(app_name, container):
     response = (
         docker.from_env()
         .containers.run(

--- a/flows/knack/knack_services.py
+++ b/flows/knack/knack_services.py
@@ -232,7 +232,8 @@ def agol_build_markings_segment_geometries(layer, date_filter, environment_varia
             .decode("utf-8")
         )
         logger.info(response)
-    return response
+        return response
+    return
 
 
 # Update the date stored in the key value in Prefect

--- a/flows/knack/knack_services.py
+++ b/flows/knack/knack_services.py
@@ -315,33 +315,36 @@ with Flow(
     records_to_postgrest(app_name, container, date_filter, environment_variables)
     # 3. Send data from Postgrest to AGOL
     records_to_agol(
-        upstream_tasks=[records_to_postgrest],
         app_name,
         container,
         date_filter,
         environment_variables,
+        upstream_tasks=[records_to_postgrest],
     )
     # 4. Send data from Postgrest to Socrata
     records_to_socrata(
-        upstream_tasks=[records_to_postgrest],
         app_name,
         container,
         date_filter,
         environment_variables,
+        upstream_tasks=[records_to_postgrest],
     )
     # 5. Build line geometries in AGOL (optional)
     if layer:
         agol_build_markings_segment_geometries(
-            upstream_tasks=[records_to_agol], layer, date_filter, environment_variables
+            layer,
+            date_filter,
+            environment_variables,
+            upstream_tasks=[records_to_agol],
         )
     # 6. Send data to another knack app (optional)
     if app_name_dest:
         records_to_knack(
-            upstream_tasks=[records_to_postgrest],
             app_name,
             container,
             app_name_dest,
             environment_variables,
+            upstream_tasks=[records_to_postgrest],
         )
 
     # 6. (if successful) update exec date

--- a/flows/knack/knack_services.py
+++ b/flows/knack/knack_services.py
@@ -71,7 +71,7 @@ def pull_docker_image():
 # Get the envrioment variables for the given app
 @task(
     name="get_env_vars",
-    task_run_name="get_env_vars:{app}",
+    # task_run_name="get_env_vars:{app}",
     max_retries=1,
     timeout=timedelta(minutes=60),
     retry_delay=timedelta(minutes=5),
@@ -86,7 +86,7 @@ def get_env_vars(app):
 # Get the last date (string) the flow was succesful
 @task(
     name="get_last_exec_time",
-    task_run_name="get_last_exec_time (app: {app}, container: {container})",
+    # task_run_name="get_last_exec_time (app: {app}, container: {container})",
     max_retries=1,
     timeout=timedelta(minutes=60),
     retry_delay=timedelta(minutes=5),
@@ -120,7 +120,7 @@ def get_last_exec_time(app, container, replace_data):
 # Records to postgrest
 @task(
     name="records_to_postgrest",
-    task_run_name="records_to_postgrest (app: {app_name}, contianer: {container}, date_filter:{date_filter})",
+    # task_run_name="records_to_postgrest (app: {app_name}, contianer: {container}, date_filter:{date_filter})",
     max_retries=1,
     timeout=timedelta(minutes=60),
     retry_delay=timedelta(minutes=5),
@@ -149,7 +149,7 @@ def records_to_postgrest(app_name, container, date_filter, environment_variables
 # Records to AGOL
 @task(
     name="records_to_agol",
-    task_run_name="records_to_agol (app: {app_name}, container: {container}, date_filter: {date_filter})",
+    # task_run_name="records_to_agol (app: {app_name}, container: {container}, date_filter: {date_filter})",
     max_retries=1,
     timeout=timedelta(minutes=60),
     retry_delay=timedelta(minutes=5),
@@ -178,7 +178,7 @@ def records_to_agol(app_name, container, date_filter, environment_variables):
 # Records to Socrata
 @task(
     name="records_to_socrata",
-    task_run_name="records_to_socrata (app: {app_name}, container: {container}, date_filter: {date_filter})",
+    # task_run_name="records_to_socrata (app: {app_name}, container: {container}, date_filter: {date_filter})",
     max_retries=1,
     timeout=timedelta(minutes=60),
     retry_delay=timedelta(minutes=5),
@@ -207,7 +207,7 @@ def records_to_socrata(app_name, container, date_filter, environment_variables):
 # Building AGOL segment geometries
 @task(
     name="agol_build_markings_segment_geometries",
-    task_run_name="agol_build_markings_segment_geometries (layer: {layer}, date_filter: {date_filter})",
+    # task_run_name="agol_build_markings_segment_geometries (layer: {layer}, date_filter: {date_filter})",
     max_retries=1,
     timeout=timedelta(minutes=60),
     retry_delay=timedelta(minutes=5),
@@ -238,7 +238,7 @@ def agol_build_markings_segment_geometries(layer, date_filter, environment_varia
 # Send Records to a destination knack app
 @task(
     name="records_to_knack",
-    task_run_name="records_to_knack (app_name_src: {app_name_src}, container_src: {container_src}, app_name_dest: {app_name_dest})",
+    # task_run_name="records_to_knack (app_name_src: {app_name_src}, container_src: {container_src}, app_name_dest: {app_name_dest})",
     max_retries=1,
     timeout=timedelta(minutes=60),
     retry_delay=timedelta(minutes=5),

--- a/flows/knack/knack_services.py
+++ b/flows/knack/knack_services.py
@@ -238,7 +238,7 @@ def agol_build_markings_segment_geometries(layer, date_filter, environment_varia
 # Send Records to a destination knack app
 @task(
     name="records_to_knack",
-    task_run_name="records_to_knack (layer: {layer}, date_filter: {date_filter})",
+    task_run_name="records_to_knack (app_name_src: {app_name_src}, container_src: {container_src}, app_name_dest: {app_name_dest})",
     max_retries=1,
     timeout=timedelta(minutes=60),
     retry_delay=timedelta(minutes=5),
@@ -298,11 +298,11 @@ with Flow(
     run_config=LocalRun(labels=["atd-data02", "production"]),
     schedule=None,
 ) as flow:
-    app_name = Parameter("apps", default=APP_NAME, required=False)
-    container = Parameter("containers", default=CONTAINER, required=False)
+    app_name = Parameter("apps", default=APP_NAME, required=True)
+    container = Parameter("containers", default=CONTAINER, required=True)
     layer = Parameter("layers", default=LAYER_NAME, required=False)
     replace_data = Parameter("replace_data", default=REPLACE_DATA, required=True)
-    app_name_dest = Parameter("app_name_dest", default=APP_NAME_DEST, required=True)
+    app_name_dest = Parameter("app_name_dest", default=APP_NAME_DEST, required=False)
 
     # Get the last time the flow ran for this app/container combo
     date_filter = get_last_exec_time(app_name, container, replace_data)

--- a/flows/knack/knack_services.py
+++ b/flows/knack/knack_services.py
@@ -16,7 +16,7 @@ import prefect
 from datetime import datetime, timedelta
 
 # Prefect
-from prefect import Flow, task
+from prefect import Flow, task, Parameter
 from prefect.storage import GitHub
 from prefect.run_configs import LocalRun
 from prefect.engine.state import Failed
@@ -34,8 +34,8 @@ CONFIG = [
 ]
 
 # Report names and ids separated from dicts
-app_names = [i["name"] for i in REPORTS]
-containers = [i["id"] for i in REPORTS]
+app_names = [i["apps"] for i in CONFIG]
+containers = [i["containers"] for i in CONFIG]
 
 # Define current environment
 current_environment = "test"
@@ -109,9 +109,9 @@ def records_to_postgrest(app_name, container):
     # state_handlers=[handler],
     log_stdout=True,
 )
-def records_to_agol():
+def records_to_agol(app_name, container):
     response = (
-        docker.from_env(app_name, container)
+        docker.from_env()
         .containers.run(
             image=docker_image,
             working_dir=None,

--- a/flows/knack/knack_services.py
+++ b/flows/knack/knack_services.py
@@ -216,21 +216,22 @@ def records_to_socrata(app_name, container, date_filter, environment_variables):
     log_stdout=True,
 )
 def agol_build_markings_segment_geometries(layer, date_filter, environment_variables):
-    response = (
-        docker.from_env()
-        .containers.run(
-            image=docker_image,
-            working_dir=None,
-            command=f"python atd-knack-services/services/agol_build_markings_segment_geometries.py -l {layer} -d {date_filter}",
-            environment=environment_variables,
-            volumes=None,
-            remove=True,
-            detach=False,
-            stdout=True,
+    if layer:
+        response = (
+            docker.from_env()
+            .containers.run(
+                image=docker_image,
+                working_dir=None,
+                command=f"python atd-knack-services/services/agol_build_markings_segment_geometries.py -l {layer} -d {date_filter}",
+                environment=environment_variables,
+                volumes=None,
+                remove=True,
+                detach=False,
+                stdout=True,
+            )
+            .decode("utf-8")
         )
-        .decode("utf-8")
-    )
-    logger.info(response)
+        logger.info(response)
     return response
 
 

--- a/flows/knack/knack_services.py
+++ b/flows/knack/knack_services.py
@@ -317,7 +317,7 @@ with Flow(
         container,
         date_filter,
         environment_variables,
-        upstream_tasks=[pull_docker_image],
+        # upstream_tasks=[pull_docker_image],
     )
     # 3. Send data from Postgrest to AGOL
     records_to_agol(
@@ -325,7 +325,7 @@ with Flow(
         container,
         date_filter,
         environment_variables,
-        upstream_tasks=[pull_docker_image, records_to_postgrest],
+        # upstream_tasks=[pull_docker_image, records_to_postgrest],
     )
     # 4. Send data from Postgrest to Socrata
     records_to_socrata(
@@ -333,7 +333,7 @@ with Flow(
         container,
         date_filter,
         environment_variables,
-        upstream_tasks=[pull_docker_image, records_to_postgrest],
+        # upstream_tasks=[pull_docker_image, records_to_postgrest],
     )
     # 5. Build line geometries in AGOL (optional)
     if layer:
@@ -341,7 +341,7 @@ with Flow(
             layer,
             date_filter,
             environment_variables,
-            upstream_tasks=[pull_docker_image, records_to_agol],
+            # upstream_tasks=[pull_docker_image, records_to_agol],
         )
     # 6. Send data to another knack app (optional)
     if app_name_dest:
@@ -350,7 +350,7 @@ with Flow(
             container,
             app_name_dest,
             environment_variables,
-            upstream_tasks=[pull_docker_image, records_to_postgrest],
+            # upstream_tasks=[pull_docker_image, records_to_postgrest],
         )
 
     # 6. (if successful) update exec date

--- a/flows/knack/knack_services.py
+++ b/flows/knack/knack_services.py
@@ -93,7 +93,7 @@ def get_env_vars(app):
 # Get the last date (string) the flow was succesful
 @task(
     name="get_last_exec_time",
-    task_run_name="get_last_exec_time:{app}-{container}",
+    task_run_name="get_last_exec_time (app:{app}, container:{container})",
     max_retries=1,
     timeout=timedelta(minutes=60),
     retry_delay=timedelta(minutes=5),
@@ -127,7 +127,7 @@ def get_last_exec_time(app, container, replace_data):
 # Records to postgrest
 @task(
     name="records_to_postgrest",
-    task_run_name="records_to_postgrest:{app_name}-{container}-{date_filter}",
+    task_run_name="records_to_postgrest (app: {app_name}, contianer: {container}, date_filter:{date_filter})",
     max_retries=1,
     timeout=timedelta(minutes=60),
     retry_delay=timedelta(minutes=5),
@@ -156,7 +156,7 @@ def records_to_postgrest(app_name, container, date_filter, environment_variables
 # Records to AGOL
 @task(
     name="records_to_agol",
-    task_run_name="records_to_agol:{app_name}-{container}-{date_filter}",
+    task_run_name="records_to_agol (app:{app_name}, container:{container}, date_filter:{date_filter})",
     max_retries=1,
     timeout=timedelta(minutes=60),
     retry_delay=timedelta(minutes=5),
@@ -185,7 +185,7 @@ def records_to_agol(app_name, container, date_filter, environment_variables):
 # Records to Socrata
 @task(
     name="records_to_socrata",
-    task_run_name="records_to_socrata:{app_name}-{container}-{date_filter}",
+    task_run_name="records_to_socrata (app: {app_name}, container:{container}, date_filter:{date_filter})",
     max_retries=1,
     timeout=timedelta(minutes=60),
     retry_delay=timedelta(minutes=5),
@@ -214,7 +214,7 @@ def records_to_socrata(app_name, container, date_filter, environment_variables):
 # Building AGOL segment geometries
 @task(
     name="agol_build_markings_segment_geometries",
-    task_run_name="agol_build_markings_segment_geometries:{layer}-{date_filter}",
+    task_run_name="agol_build_markings_segment_geometries (layer: {layer}, date_filter:{date_filter})",
     max_retries=1,
     timeout=timedelta(minutes=60),
     retry_delay=timedelta(minutes=5),

--- a/flows/knack/knack_services.py
+++ b/flows/knack/knack_services.py
@@ -312,14 +312,20 @@ with Flow(
     # 1. Pull latest docker image
     pull_docker_image()
     # 2. Download Knack records and send them to Postgres(t)
-    records_to_postgrest(app_name, container, date_filter, environment_variables)
+    records_to_postgrest(
+        app_name,
+        container,
+        date_filter,
+        environment_variables,
+        upstream_tasks=[pull_docker_image],
+    )
     # 3. Send data from Postgrest to AGOL
     records_to_agol(
         app_name,
         container,
         date_filter,
         environment_variables,
-        upstream_tasks=[records_to_postgrest],
+        upstream_tasks=[pull_docker_image, records_to_postgrest],
     )
     # 4. Send data from Postgrest to Socrata
     records_to_socrata(
@@ -327,7 +333,7 @@ with Flow(
         container,
         date_filter,
         environment_variables,
-        upstream_tasks=[records_to_postgrest],
+        upstream_tasks=[pull_docker_image, records_to_postgrest],
     )
     # 5. Build line geometries in AGOL (optional)
     if layer:
@@ -335,7 +341,7 @@ with Flow(
             layer,
             date_filter,
             environment_variables,
-            upstream_tasks=[records_to_agol],
+            upstream_tasks=[pull_docker_image, records_to_agol],
         )
     # 6. Send data to another knack app (optional)
     if app_name_dest:
@@ -344,7 +350,7 @@ with Flow(
             container,
             app_name_dest,
             environment_variables,
-            upstream_tasks=[records_to_postgrest],
+            upstream_tasks=[pull_docker_image, records_to_postgrest],
         )
 
     # 6. (if successful) update exec date

--- a/flows/knack/knack_services.py
+++ b/flows/knack/knack_services.py
@@ -185,10 +185,10 @@ with Flow(
     pull_docker_image()
 
     # 2. Download Knack records and send them to Postgres(t)
-    records_to_postgrest(app_name, container)
+    records_to_postgrest.map(app_name, container)
 
     # 3. Send data from Postgrest to AGOL
-    records_to_agol(app_name, container)
+    records_to_agol.map(app_name, container)
 
     # 4. Build line geometries in AGOL
     agol_build_markings_segment_geometries()

--- a/flows/knack/knack_services.py
+++ b/flows/knack/knack_services.py
@@ -248,24 +248,22 @@ def agol_build_markings_segment_geometries(layer, date_filter, environment_varia
 def records_to_knack(
     app_name_src, container_src, date_filter, app_name_dest, environment_variables
 ):
-    if layer:
-        response = (
-            docker.from_env()
-            .containers.run(
-                image=docker_image,
-                working_dir=None,
-                command=f"python atd-knack-services/services/records_to_knack.py -a {app_name_src} -c {container_src} -d {date_filter} -dest {app_name_dest}",
-                environment=environment_variables,
-                volumes=None,
-                remove=True,
-                detach=False,
-                stdout=True,
-            )
-            .decode("utf-8")
+    response = (
+        docker.from_env()
+        .containers.run(
+            image=docker_image,
+            working_dir=None,
+            command=f"python atd-knack-services/services/records_to_knack.py -a {app_name_src} -c {container_src} -d {date_filter} -dest {app_name_dest}",
+            environment=environment_variables,
+            volumes=None,
+            remove=True,
+            detach=False,
+            stdout=True,
         )
-        logger.info(response)
-        return response
-    return
+        .decode("utf-8")
+    )
+    logger.info(response)
+    return response
 
 
 # Update the date stored in the key value in Prefect
@@ -351,8 +349,8 @@ with Flow(
             app_name,
             container,
             date_filter,
-            environment_variables,
             app_name_dest,
+            environment_variables,
             upstream_tasks=[docker_pull, postgrest_res],
         )
 


### PR DESCRIPTION
This Prefect flow was created with [10002](https://github.com/cityofaustin/atd-data-tech/issues/10002) and [7442](https://github.com/cityofaustin/atd-data-tech/issues/7442) in mind to add roadway markings contractor work orders to Knack-services to upload data from Knack to Postgres, AGOL, and Socrata.

This flow uses the docker image automatically created by [this repo](https://github.com/cityofaustin/atd-knack-services). When it is run, it will pull the latest docker image and then run a series of commands inside that container.

In theory, this flow should be able to be configured to run any of our atd-knack-services DAGs currently in airflow.

More in README...

