### PR TITLE
atd-service-bot to Prefect

### DIFF
--- a/flows/service-bot/intake_issues.py
+++ b/flows/service-bot/intake_issues.py
@@ -28,7 +28,7 @@ from prefect.utilities.notifications import slack_notifier
 DOCKER_TAG = "test"
 
 # Envrioment vars
-ENV = "test"
+ENV = "production"
 
 # Set up slack fail handler
 handler = slack_notifier(only_states=[Failed])

--- a/flows/service-bot/intake_issues.py
+++ b/flows/service-bot/intake_issues.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python
+
+"""
+Name: ATD Service Bot: Intake Issues
+Description: Sends new issue data from our service portal (knack) to our Github
+Repo atd-data-tech
+Schedule: * * * * * (AKA once every minute)
+Labels: WIP
+"""
+
+import os
+
+import docker
+import prefect
+from datetime import datetime, timedelta
+
+# Prefect
+from prefect import Flow, task, Parameter, unmapped, case
+from prefect.storage import GitHub
+from prefect.run_configs import LocalRun
+from prefect.engine.state import Failed
+from prefect.schedules import Schedule
+from prefect.schedules.clocks import CronClock
+from prefect.backend import set_key_value, get_key_value
+from prefect.triggers import all_successful
+from prefect.tasks.docker import PullImage
+
+
+from prefect.utilities.notifications import slack_notifier
+
+# Select the appropriate tag for the Docker Image
+# docker_env will also be taken as a parameter
+DOCKER_TAG = "test"
+
+# Envrioment vars
+ENV = "test"
+
+# Set up slack fail handler
+handler = slack_notifier(only_states=[Failed])
+
+# Logger instance
+logger = prefect.context.get("logger")
+
+# Task to pull the latest Docker image
+@task(
+    name="pull_docker_image",
+    max_retries=1,
+    timeout=timedelta(minutes=60),
+    retry_delay=timedelta(minutes=5),
+    # state_handlers=[handler],
+    log_stdout=True,
+)
+def pull_docker_image(docker_tag):
+    docker_image = f"atddocker/atd-service-bot:{docker_tag}"
+    client = docker.from_env()
+    response = client.images.pull("atddocker/atd-service-bot", tag=docker_tag)
+    logger.info(f"Docker Images Pulled, using: {docker_image}")
+    return docker_image
+
+
+# Get the envrioment variables based on the given environment
+@task(
+    name="get_env_vars",
+    task_run_name="get_env_vars",
+    max_retries=1,
+    timeout=timedelta(minutes=60),
+    retry_delay=timedelta(minutes=5),
+    # state_handlers=[handler],
+    log_stdout=True,
+)
+def get_env_vars():
+    environment_variables = get_key_value(key=f"atd_service_bot_{ENV}")
+    logger.info(f"Recieved Prefect Environment Variables for: {docker_image}")
+    return environment_variables
+
+
+# Issues to Socrata
+@task(
+    name="intake_new_issues",
+    max_retries=1,
+    timeout=timedelta(minutes=60),
+    retry_delay=timedelta(minutes=5),
+    # state_handlers=[handler],
+    log_stdout=True,
+)
+def intake_new_issues(environment_variables, docker_image):
+    response = (
+        docker.from_env()
+        .containers.run(
+            image=docker_image,
+            working_dir=None,
+            command=f"python atd-service-bot/intake.py",
+            environment=environment_variables,
+            volumes=None,
+            remove=True,
+            detach=False,
+            stdout=True,
+        )
+        .decode("utf-8")
+    )
+    logger.info(response)
+    return response
+
+
+with Flow(
+    # Flow Name
+    "sb_intake_issues_test",
+    # Let's configure the agents to download the file from this repo
+    storage=GitHub(
+        repo="cityofaustin/atd-prefect",
+        path="flows/service-bot/intake_issues.py",
+        ref="ch-atd-service-bot",  # The branch name
+    ),
+    run_config=LocalRun(labels=["atd-data02", "test"]),
+    schedule=None,
+) as flow:
+    # Parameter task
+    docker_tag = Parameter(
+        "Tag of the atd-service-bot Docker image", default=DOCKER_TAG, required=True
+    )
+
+    # 1. Get secrets from Prefect KV Store
+    environment_variables = get_env_vars()
+
+    # 2. Pull latest docker image
+    docker_image = pull_docker_image(docker_tag)
+
+    # 3. Intake new issues to github
+    res = intake_new_issues(environment_variables, docker_image)
+
+if __name__ == "__main__":
+    flow.run(
+        parameters={"Docker image tag": DOCKER_TAG,}
+    )

--- a/flows/service-bot/intake_issues.py
+++ b/flows/service-bot/intake_issues.py
@@ -39,10 +39,8 @@ logger = prefect.context.get("logger")
 # Task to pull the latest Docker image
 @task(
     name="pull_docker_image",
-    max_retries=1,
-    timeout=timedelta(minutes=60),
-    retry_delay=timedelta(minutes=5),
-    # state_handlers=[handler],
+    timeout=timedelta(minutes=1),
+    state_handlers=[handler],
     log_stdout=True,
 )
 def pull_docker_image(docker_tag):
@@ -56,11 +54,8 @@ def pull_docker_image(docker_tag):
 # Get the envrioment variables based on the given environment
 @task(
     name="get_env_vars",
-    task_run_name="get_env_vars",
-    max_retries=1,
-    timeout=timedelta(minutes=60),
-    retry_delay=timedelta(minutes=5),
-    # state_handlers=[handler],
+    timeout=timedelta(minutes=1),
+    state_handlers=[handler],
     log_stdout=True,
 )
 def get_env_vars():
@@ -69,13 +64,11 @@ def get_env_vars():
     return environment_variables
 
 
-# Issues to Socrata
+# Knack Issues to Github
 @task(
     name="intake_new_issues",
-    max_retries=1,
-    timeout=timedelta(minutes=60),
-    retry_delay=timedelta(minutes=5),
-    # state_handlers=[handler],
+    timeout=timedelta(minutes=1),
+    state_handlers=[handler],
     log_stdout=True,
 )
 def intake_new_issues(environment_variables, docker_image):
@@ -99,7 +92,7 @@ def intake_new_issues(environment_variables, docker_image):
 
 with Flow(
     # Flow Name
-    "sb_intake_issues_test",
+    "Service Bot: Intake Issues",
     # Let's configure the agents to download the file from this repo
     storage=GitHub(
         repo="cityofaustin/atd-prefect",

--- a/flows/service-bot/issues_to_socrata.py
+++ b/flows/service-bot/issues_to_socrata.py
@@ -28,7 +28,7 @@ from prefect.utilities.notifications import slack_notifier
 DOCKER_TAG = "test"
 
 # Envrioment vars
-ENV = "test"
+ENV = "production"
 
 # Set up slack fail handler
 handler = slack_notifier(only_states=[Failed])

--- a/flows/service-bot/issues_to_socrata.py
+++ b/flows/service-bot/issues_to_socrata.py
@@ -42,7 +42,7 @@ logger = prefect.context.get("logger")
     max_retries=1,
     timeout=timedelta(minutes=60),
     retry_delay=timedelta(minutes=5),
-    # state_handlers=[handler],
+    state_handlers=[handler],
     log_stdout=True,
 )
 def pull_docker_image(docker_tag):
@@ -60,7 +60,7 @@ def pull_docker_image(docker_tag):
     max_retries=1,
     timeout=timedelta(minutes=60),
     retry_delay=timedelta(minutes=5),
-    # state_handlers=[handler],
+    state_handlers=[handler],
     log_stdout=True,
 )
 def get_env_vars():
@@ -75,7 +75,7 @@ def get_env_vars():
     max_retries=1,
     timeout=timedelta(minutes=60),
     retry_delay=timedelta(minutes=5),
-    # state_handlers=[handler],
+    state_handlers=[handler],
     log_stdout=True,
 )
 def sending_issues_to_socrata(environment_variables, docker_image):
@@ -99,7 +99,7 @@ def sending_issues_to_socrata(environment_variables, docker_image):
 
 with Flow(
     # Flow Name
-    "sb_issues_to_socrata_test",
+    "Service Bot: Issues to Open Data Portal",
     # Let's configure the agents to download the file from this repo
     storage=GitHub(
         repo="cityofaustin/atd-prefect",

--- a/flows/service-bot/issues_to_socrata.py
+++ b/flows/service-bot/issues_to_socrata.py
@@ -111,7 +111,7 @@ with Flow(
         path="flows/service-bot/issues_to_socrata.py",
         ref="ch-atd-service-bot",  # The branch name
     ),
-    run_config=LocalRun(labels=["charliesmacbook", "local"]),
+    run_config=LocalRun(labels=["atd-data02", "test"]),
     schedule=None,
 ) as flow:
     # Parameter task

--- a/flows/service-bot/issues_to_socrata.py
+++ b/flows/service-bot/issues_to_socrata.py
@@ -80,7 +80,7 @@ def get_env_vars():
     max_retries=1,
     timeout=timedelta(minutes=60),
     retry_delay=timedelta(minutes=5),
-    state_handlers=[handler],
+    # state_handlers=[handler],
     log_stdout=True,
 )
 def sending_issues_to_socrata(environment_variables, docker_image):

--- a/flows/service-bot/issues_to_socrata.py
+++ b/flows/service-bot/issues_to_socrata.py
@@ -8,22 +8,17 @@ Schedule: 21 5 * * * (UTC)
 Labels: WIP
 """
 
-import os
-
 import docker
 import prefect
-from datetime import datetime, timedelta
+from datetime import timedelta
+
 
 # Prefect
-from prefect import Flow, task, Parameter, unmapped, case
+from prefect import Flow, task, Parameter
 from prefect.storage import GitHub
 from prefect.run_configs import LocalRun
 from prefect.engine.state import Failed
-from prefect.schedules import Schedule
-from prefect.schedules.clocks import CronClock
-from prefect.backend import set_key_value, get_key_value
-from prefect.triggers import all_successful
-from prefect.tasks.docker import PullImage
+from prefect.backend import get_key_value
 
 
 from prefect.utilities.notifications import slack_notifier

--- a/flows/service-bot/issues_to_socrata.py
+++ b/flows/service-bot/issues_to_socrata.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python
+
+"""
+Name: ATD Service Bot: Issues to Socrata
+Description: Uploads (replaces) github issue data from our atd-data-tech repo 
+to an Open Data Portal dataset (AKA Socrata)
+Schedule: 21 5 * * * (UTC)
+Labels: WIP
+"""
+
+import os
+
+import docker
+import prefect
+from datetime import datetime, timedelta
+
+# Prefect
+from prefect import Flow, task, Parameter, unmapped, case
+from prefect.storage import GitHub
+from prefect.run_configs import LocalRun
+from prefect.engine.state import Failed
+from prefect.schedules import Schedule
+from prefect.schedules.clocks import CronClock
+from prefect.backend import set_key_value, get_key_value
+from prefect.triggers import all_successful
+from prefect.tasks.docker import PullImage
+
+
+from prefect.utilities.notifications import slack_notifier
+
+# Select the appropriate tag for the Docker Image
+# docker_env will also be taken as a parameter
+DOCKER_TAG = "test"
+
+# Envrioment vars
+ENV = "test"
+
+# Set up slack fail handler
+handler = slack_notifier(only_states=[Failed])
+
+# Logger instance
+logger = prefect.context.get("logger")
+
+# Task to pull the latest Docker image
+@task(
+    name="pull_docker_image",
+    max_retries=1,
+    timeout=timedelta(minutes=60),
+    retry_delay=timedelta(minutes=5),
+    # state_handlers=[handler],
+    log_stdout=True,
+)
+def pull_docker_image(docker_tag):
+    docker_image = f"atddocker/atd-service-bot:{docker_tag}"
+    client = docker.from_env()
+    response = client.images.pull("atddocker/atd-service-bot", tag=docker_tag)
+    logger.info(f"Docker Images Pulled, using: {docker_image}")
+    return docker_image
+
+
+# Get the envrioment variables based on the given environment
+@task(
+    name="get_env_vars",
+    task_run_name="get_env_vars",
+    max_retries=1,
+    timeout=timedelta(minutes=60),
+    retry_delay=timedelta(minutes=5),
+    # state_handlers=[handler],
+    log_stdout=True,
+)
+def get_env_vars():
+    environment_variables = get_key_value(key=f"atd_service_bot_{ENV}")
+    logger.info(f"Recieved Prefect Environment Variables for: {docker_image}")
+    return environment_variables
+
+
+# Issues to Socrata
+@task(
+    name="sending_issues_to_socrata",
+    max_retries=1,
+    timeout=timedelta(minutes=60),
+    retry_delay=timedelta(minutes=5),
+    state_handlers=[handler],
+    log_stdout=True,
+)
+def sending_issues_to_socrata(environment_variables, docker_image):
+    response = (
+        docker.from_env()
+        .containers.run(
+            image=docker_image,
+            working_dir=None,
+            command=f"python atd-service-bot/issues_to_socrata.py",
+            environment=environment_variables,
+            volumes=None,
+            remove=True,
+            detach=False,
+            stdout=True,
+        )
+        .decode("utf-8")
+    )
+    logger.info(response)
+    return response
+
+
+with Flow(
+    # Flow Name
+    "sb_issues_to_socrata_test",
+    # Let's configure the agents to download the file from this repo
+    storage=GitHub(
+        repo="cityofaustin/atd-prefect",
+        path="flows/service-bot/issues_to_socrata.py",
+        ref="ch-atd-service-bot",  # The branch name
+    ),
+    run_config=LocalRun(labels=["charliesmacbook", "local"]),
+    schedule=None,
+) as flow:
+    # Parameter task
+    docker_tag = Parameter(
+        "Tag of the atd-service-bot Docker image", default=DOCKER_TAG, required=True
+    )
+
+    # 1. Get secrets from Prefect KV Store
+    environment_variables = get_env_vars()
+
+    # 2. Pull latest docker image
+    docker_image = pull_docker_image(docker_tag)
+
+    # 3. Send issue data to Socrata
+    res = sending_issues_to_socrata(environment_variables, docker_image)
+
+if __name__ == "__main__":
+    flow.run(
+        parameters={"Docker image tag": DOCKER_TAG,}
+    )

--- a/flows/service-bot/update_issues.py
+++ b/flows/service-bot/update_issues.py
@@ -2,7 +2,7 @@
 
 """
 Name: ATD Service Bot: Update Issues
-Description: Updates issues in our DTS portal (Knack) with new data from Github
+Description: Updates projects in our DTS portal (Knack) with new data from Github
 Schedule: 13 7 * * * (UTC)
 Labels: WIP
 """

--- a/flows/service-bot/update_issues.py
+++ b/flows/service-bot/update_issues.py
@@ -27,7 +27,7 @@ from prefect.utilities.notifications import slack_notifier
 DOCKER_TAG = "test"
 
 # Envrioment vars
-ENV = "test"
+ENV = "production"
 
 # Set up slack fail handler
 handler = slack_notifier(only_states=[Failed])

--- a/flows/service-bot/update_issues.py
+++ b/flows/service-bot/update_issues.py
@@ -41,7 +41,7 @@ logger = prefect.context.get("logger")
     max_retries=1,
     timeout=timedelta(minutes=60),
     retry_delay=timedelta(minutes=5),
-    # state_handlers=[handler],
+    state_handlers=[handler],
     log_stdout=True,
 )
 def pull_docker_image(docker_tag):
@@ -59,7 +59,7 @@ def pull_docker_image(docker_tag):
     max_retries=1,
     timeout=timedelta(minutes=60),
     retry_delay=timedelta(minutes=5),
-    # state_handlers=[handler],
+    state_handlers=[handler],
     log_stdout=True,
 )
 def get_env_vars():
@@ -68,13 +68,13 @@ def get_env_vars():
     return environment_variables
 
 
-# Issues to Socrata
+# Index Issues to Knack
 @task(
     name="update_knack_issues",
     max_retries=1,
     timeout=timedelta(minutes=60),
     retry_delay=timedelta(minutes=5),
-    # state_handlers=[handler],
+    state_handlers=[handler],
     log_stdout=True,
 )
 def update_knack_issues(environment_variables, docker_image):
@@ -98,7 +98,7 @@ def update_knack_issues(environment_variables, docker_image):
 
 with Flow(
     # Flow Name
-    "sb_update_issues_test",
+    "Service Bot: Update Issues",
     # Let's configure the agents to download the file from this repo
     storage=GitHub(
         repo="cityofaustin/atd-prefect",

--- a/flows/service-bot/update_issues.py
+++ b/flows/service-bot/update_issues.py
@@ -102,7 +102,7 @@ with Flow(
     # Let's configure the agents to download the file from this repo
     storage=GitHub(
         repo="cityofaustin/atd-prefect",
-        path="flows/service-bot/intake_issues.py",
+        path="flows/service-bot/update_issues.py",
         ref="ch-atd-service-bot",  # The branch name
     ),
     run_config=LocalRun(labels=["atd-data02", "test"]),


### PR DESCRIPTION
Porting these three Airflow DAGs to Prefect:
- https://github.com/cityofaustin/atd-airflow/blob/master/dags/atd_service_bot_index_issues_to_dts_portal.py
- https://github.com/cityofaustin/atd-airflow/blob/master/dags/atd_service_bot_issues_to_socrata.py
- https://github.com/cityofaustin/atd-airflow/blob/master/dags/atd_service_bot_production.py

These DAGs currently manage our github issues. It creates new issues based data from people filling out the service request form in Knack. It also will publish these issues nightly to Socrata. Finally, it will update our project issues (those with the label `Project Index`) in Knack with the latest details from Github if anything changes.

Issue: https://github.com/cityofaustin/atd-data-tech/issues/10633

This is currently pointed to a test Socrata dataset and is fed by a copy of the DTS service knack app. When we move this into production, I'll have to change our secrets over to production along with the docker tag.

[Test Knack App](https://builder.knack.com/atd/dts--data-and-technology-services-portal--production-copy/schema/list)
[Test Socrata dataset](https://data.austintexas.gov/dataset/TEST-ATD-Data-Tech-Services-Issues/93ru-6p6e)

Not currently scheduled, so we don't step on the toes of the existing DAG but it'll be:
`intake_issues.py` : */3 * * * * AKA every 1 minute 
`issues_to_socrata.py` : 21 5 * * *  AKA once daily at 05:21 UTC
`update_issues.py` 13 7 * * * AKA once daily at 07:13 UTC

Since these flows are running on three different schedules I've created three different flow files, however I don't see why we couldn't combine `update_issues` and `issues_to_socrata`.

We'll have to schedule a time where we switch off the airflow DAG and activate the Prefect one.

The only parameter these flows take is `DOCKER_TAG` which will determine which docker container to use if we want to test new code in `atd-service-bot`. Maybe I should parameterize `ENV` where we can change which set of secrets to use for our flow?