### PR TITLE
Pinning Prefect Version

### DIFF
--- a/.github/workflows/register_flows.yml
+++ b/.github/workflows/register_flows.yml
@@ -38,7 +38,7 @@ jobs:
       - name: "Installing Prefect"
         run: |
           sudo apt-get install -y python3-setuptools
-          pip3 install awscli boto3 virtualenv requests prefect
+          pip3 install awscli boto3 virtualenv requests "prefect==1.*"
       # Run the shell commands using the AWS environment variables
       - name: "Register Flows"
         env:


### PR DESCRIPTION
We made this patch in main branch, but not in production so the auto-registering Github action was failing because pip was installing Prefect 2.0. Pinning here to 1.X. 

Only affects flows that get auto-registered so they must contain `if __name__ == "__main__":`