### PR TITLE
Finance-Data ETL

### DIFF
--- a/flows/finance-data/finance_data_to_s3.py
+++ b/flows/finance-data/finance_data_to_s3.py
@@ -90,7 +90,7 @@ def upload_to_knack():
         .containers.run(
             image=docker_image,
             working_dir=None,
-            command="python upload_to_s3.py s3_to_knack.py task_orders finance-purchasing",
+            command="python s3_to_knack.py task_orders finance-purchasing",
             environment=environment_variables,
             volumes=None,
             remove=True,

--- a/flows/finance-data/finance_data_to_s3.py
+++ b/flows/finance-data/finance_data_to_s3.py
@@ -93,7 +93,7 @@ with Flow(
     run_config=UniversalRun(labels=["test", "atd-data02"]),
     #schedule=Schedule(clocks=[CronClock("30 12 * * *")]),
 ) as flow:
-    flow.chain(pull_docker_image, s3_to_socrata)
+    flow.chain(pull_docker_image, upload_to_s3)
 
 if __name__ == "__main__":
     flow.run()

--- a/flows/finance-data/finance_data_to_s3.py
+++ b/flows/finance-data/finance_data_to_s3.py
@@ -163,21 +163,33 @@ with Flow(
     docker_res = pull_docker_image()
 
     with case(docker_res, True):
-        task_orders_res = upload_to_s3(environment_variables, "task_orders")
-        upload_to_knack(
-            environment_variables, "task_orders", "finance-purchasing", task_orders_res
+        task_orders_res = upload_to_s3(
+            environment_variables["data-tracker"], "task_orders"
         )
         upload_to_knack(
-            environment_variables, "task_orders", "data-tracker", task_orders_res
+            environment_variables["finance-purchasing"],
+            "task_orders",
+            "finance-purchasing",
+            task_orders_res,
         )
-        units_res = upload_to_s3(environment_variables, "units")
-        upload_to_knack(environment_variables, "units", "data-tracker", units_res)
-        objects_res = upload_to_s3(environment_variables, "objects")
-        master_agreements_res = upload_to_s3(environment_variables, "master_agreements")
-        fdus_res = upload_to_s3(environment_variables, "fdus")
+        upload_to_knack(
+            environment_variables["data-tracker"],
+            "task_orders",
+            "data-tracker",
+            task_orders_res,
+        )
+        units_res = upload_to_s3(environment_variables["data-tracker"], "units")
+        upload_to_knack(
+            environment_variables["data-tracker"], "units", "data-tracker", units_res
+        )
+        objects_res = upload_to_s3(environment_variables["data-tracker"], "objects")
+        master_agreements_res = upload_to_s3(
+            environment_variables["data-tracker"], "master_agreements"
+        )
+        fdus_res = upload_to_s3(environment_variables["data-tracker"], "fdus")
 
         socrata_start = merge(task_orders_res, units_res, fdus_res)
-        upload_to_socrata(environment_variables, socrata_start)
+        upload_to_socrata(environment_variables["data-tracker"], socrata_start)
 
 
 if __name__ == "__main__":

--- a/flows/finance-data/finance_data_to_s3.py
+++ b/flows/finance-data/finance_data_to_s3.py
@@ -36,8 +36,6 @@ logger = prefect.context.get("logger")
 docker_env = "test"
 docker_image = f"atddocker/atd-finance-data:{docker_env}"
 
-github_token = get_key_value(key=f"github_access_token")
-
 
 @task(
     name="get_env_vars",
@@ -154,7 +152,7 @@ with Flow(
         repo="cityofaustin/atd-prefect",
         path="flows/finance-data/finance_data_to_s3.py",
         ref="ch-finance-data",  # The branch name
-        access_token_secret=github_token["GITHUB_ACCESS_TOKEN"],
+        access_token_secret="GITHUB_ACCESS_TOKEN",
     ),
     # Run config will always need the current_environment
     # plus whatever labels you need to attach to this flow

--- a/flows/finance-data/finance_data_to_s3.py
+++ b/flows/finance-data/finance_data_to_s3.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python
+
+"""
+Name: ATD Finance Data Flow
+Description: Gets finance data from S3 and places it in a Socrata dataset.
+Schedule: "30 12 * * *"
+Labels: atd-data02, moped
+"""
+
+import os
+
+import docker
+import prefect
+from datetime import datetime, timedelta
+
+# Prefect
+from prefect import Flow, task
+from prefect.storage import GitHub
+from prefect.run_configs import UniversalRun
+from prefect.engine.state import Failed
+from prefect.schedules import Schedule
+from prefect.schedules.clocks import CronClock
+from prefect.backend import set_key_value, get_key_value
+from prefect.triggers import all_successful
+
+from prefect.utilities.notifications import slack_notifier
+
+# Set up slack fail handler
+handler = slack_notifier(only_states=[Failed])
+
+# Logger instance
+logger = prefect.context.get("logger")
+
+# Docker settings
+docker_env = "test"
+docker_image = f"atddocker/atd-finance-data:{docker_env}"
+
+# Environment Variables from KV Store in Prefect
+environment_variables = get_key_value(key=f"atd_finance_data")
+
+
+@task(
+    name="pull_docker_image",
+    max_retries=1,
+    timeout=timedelta(minutes=60),
+    retry_delay=timedelta(minutes=5),
+    # state_handlers=[handler],
+)
+def pull_docker_image():
+    client = docker.from_env()
+    client.images.pull("atddocker/atd-finance-data", all_tags=True)
+    logger.info(docker_image)
+    return
+
+
+@task(
+    name="upload_to_s3",
+    max_retries=1,
+    timeout=timedelta(minutes=60),
+    retry_delay=timedelta(minutes=5),
+    # state_handlers=[handler],
+)
+def upload_to_s3():
+    response = (
+        docker.from_env()
+        .containers.run(
+            image=docker_image,
+            working_dir=None,
+            command="python upload_to_s3.py task_orders",
+            environment=environment_variables,
+            volumes=None,
+            remove=True,
+            detach=False,
+            stdout=True,
+        )
+        .decode("utf-8")
+    )
+    logger.info(response)
+    return response
+
+
+with Flow(
+    # Postfix the name of the flow with the environment it belongs to
+    f"Finance Data: Upload to S3",
+    # Let's configure the agents to download the file from this repo
+    storage=GitHub(
+        repo="cityofaustin/atd-prefect",
+        path="flows/finance-data/finance_data_to_s3.py",
+        ref="ch-finance-data",  # The branch name
+    ),
+    # Run config will always need the current_environment
+    # plus whatever labels you need to attach to this flow
+    run_config=UniversalRun(labels=["test", "atd-data02"]),
+    #schedule=Schedule(clocks=[CronClock("30 12 * * *")]),
+) as flow:
+    flow.chain(pull_docker_image, s3_to_socrata)
+
+if __name__ == "__main__":
+    flow.run()

--- a/flows/finance-data/finance_data_to_s3.py
+++ b/flows/finance-data/finance_data_to_s3.py
@@ -14,7 +14,7 @@ import prefect
 from datetime import datetime, timedelta
 
 # Prefect
-from prefect import Flow, task
+from prefect import Flow, task, case
 from prefect.storage import GitHub
 from prefect.run_configs import UniversalRun
 from prefect.engine.state import Failed
@@ -35,8 +35,17 @@ logger = prefect.context.get("logger")
 docker_env = "test"
 docker_image = f"atddocker/atd-finance-data:{docker_env}"
 
-# Environment Variables from KV Store in Prefect
-environment_variables = get_key_value(key=f"atd_finance_data")
+
+@task(
+    name="get_env_vars",
+    max_retries=1,
+    timeout=timedelta(minutes=60),
+    retry_delay=timedelta(minutes=5),
+    # state_handlers=[handler],
+)
+def get_env_vars():
+    # Environment Variables from KV Store in Prefect
+    return get_key_value(key=f"atd_finance_data")
 
 
 @task(
@@ -50,47 +59,23 @@ def pull_docker_image():
     client = docker.from_env()
     client.images.pull("atddocker/atd-finance-data", all_tags=True)
     logger.info(docker_image)
-    return
+    return True
 
 
 @task(
     name="upload_to_s3",
-    #max_retries=1,
-    #timeout=timedelta(minutes=60),
-    #retry_delay=timedelta(minutes=5),
+    # max_retries=1,
+    # timeout=timedelta(minutes=60),
+    # retry_delay=timedelta(minutes=5),
     # state_handlers=[handler],
 )
-def upload_to_s3():
+def upload_to_s3(environment_variables, name):
     response = (
         docker.from_env()
         .containers.run(
             image=docker_image,
             working_dir=None,
-            command="python upload_to_s3.py task_orders",
-            environment=environment_variables,
-            volumes=None,
-            remove=True,
-            detach=False,
-            stdout=True,
-        )
-        .decode("utf-8")
-    )
-    logger.info(response)
-    return response
-@task(
-    name="upload_to_knack",
-    #max_retries=1,
-    #timeout=timedelta(minutes=60),
-    #retry_delay=timedelta(minutes=5),
-    # state_handlers=[handler],
-)
-def upload_to_knack():
-    response = (
-        docker.from_env()
-        .containers.run(
-            image=docker_image,
-            working_dir=None,
-            command="python s3_to_knack.py task_orders finance-purchasing",
+            command=f"python upload_to_s3.py {name}",
             environment=environment_variables,
             volumes=None,
             remove=True,
@@ -102,9 +87,36 @@ def upload_to_knack():
     logger.info(response)
     return response
 
+
+@task(
+    name="upload_to_knack",
+    # max_retries=1,
+    # timeout=timedelta(minutes=60),
+    # retry_delay=timedelta(minutes=5),
+    # state_handlers=[handler],
+)
+def upload_to_knack(environment_variables, name, app, task_orders_res):
+    response = (
+        docker.from_env()
+        .containers.run(
+            image=docker_image,
+            working_dir=None,
+            command=f"python s3_to_knack.py {name} {app}",
+            environment=environment_variables,
+            volumes=None,
+            remove=True,
+            detach=False,
+            stdout=True,
+        )
+        .decode("utf-8")
+    )
+    logger.info(response)
+    return response
+
+
 with Flow(
     # Postfix the name of the flow with the environment it belongs to
-    f"Finance Data: Upload to S3",
+    f"Finance Data Publishing",
     # Let's configure the agents to download the file from this repo
     storage=GitHub(
         repo="cityofaustin/atd-prefect",
@@ -114,9 +126,17 @@ with Flow(
     # Run config will always need the current_environment
     # plus whatever labels you need to attach to this flow
     run_config=UniversalRun(labels=["test", "atd-data02"]),
-    #schedule=Schedule(clocks=[CronClock("30 12 * * *")]),
+    schedule=Schedule(clocks=[CronClock("13 7 * * *")]),
 ) as flow:
-    flow.chain(pull_docker_image, upload_to_s3,upload_to_knack)
+    # Start: get env vars and pull the latest docker image
+    environment_variables = get_env_vars()
+    docker_res = pull_docker_image()
+
+    with case(docker_res, True):
+        task_orders_res = upload_to_s3(environment_variables, "task_orders")
+        upload_to_knack(
+            environment_variables, "task_orders", "finance-purchasing", task_orders_res
+        )
 
 if __name__ == "__main__":
     flow.run()

--- a/flows/finance-data/finance_data_to_s3.py
+++ b/flows/finance-data/finance_data_to_s3.py
@@ -64,6 +64,7 @@ def pull_docker_image():
 
 @task(
     name="upload_to_s3",
+    task_run_name="upload_to_s3: {name}",
     # max_retries=1,
     # timeout=timedelta(minutes=60),
     # retry_delay=timedelta(minutes=5),
@@ -90,6 +91,7 @@ def upload_to_s3(environment_variables, name):
 
 @task(
     name="upload_to_knack",
+    task_run_name="upload_to_knack: {name}, {app}",
     # max_retries=1,
     # timeout=timedelta(minutes=60),
     # retry_delay=timedelta(minutes=5),

--- a/flows/finance-data/finance_data_to_s3.py
+++ b/flows/finance-data/finance_data_to_s3.py
@@ -36,6 +36,8 @@ logger = prefect.context.get("logger")
 docker_env = "test"
 docker_image = f"atddocker/atd-finance-data:{docker_env}"
 
+github_token = get_key_value(key=f"github_access_token")
+
 
 @task(
     name="get_env_vars",
@@ -152,6 +154,7 @@ with Flow(
         repo="cityofaustin/atd-prefect",
         path="flows/finance-data/finance_data_to_s3.py",
         ref="ch-finance-data",  # The branch name
+        access_token_secret=github_token["GITHUB_ACCESS_TOKEN"],
     ),
     # Run config will always need the current_environment
     # plus whatever labels you need to attach to this flow


### PR DESCRIPTION
Issue: https://github.com/cityofaustin/atd-data-tech/issues/10960

Prefect ETL for [atd-finance-data](https://github.com/cityofaustin/atd-finance-data).

Three main tasks:
- upload_to_s3
- upload_to_knack (from S3)
- upload_to_socrata (from S3)

## **Data flow currently configured:**
To S3 bucket: 
- `task_orders`
- `units`
- `fdus`
- `master_agreements`
- `objects`

To `data-tracker` Knack app:
- `task_orders`
- `units`

To `finance-purchasing` Knack app:
- `task_orders`

To Open Data Portal
- `task_orders`
- `dept_units`
- `fdus`

Aims to deprecate the following Airflow DAGs (already turned off):
- https://github.com/cityofaustin/atd-airflow/blob/master/dags/atd_finance_data_s3_to_data_tracker.py
- https://github.com/cityofaustin/atd-airflow/blob/master/dags/atd_finance_data_upload_to_s3.py

Reminders before merging for myself:
- [x] Merge this [PR](https://github.com/cityofaustin/atd-finance-data/pull/17) and change the `docker_env` to `production`
- [x] Uncomment out slack notifications `state_handlers=[handler]`
- [x] Change reference to the main branch `ref="main"`
- [x] Delete old `finance_data.py` AKA `atd_finance_staging` flow that has been replaced by this flow [PR](https://github.com/cityofaustin/atd-prefect/pull/48)