### PR TITLE
Parking Data Secrets Refresh

### DIFF
--- a/flows/parking/atd_parking_data_meters_txn_history.py
+++ b/flows/parking/atd_parking_data_meters_txn_history.py
@@ -27,7 +27,7 @@ from prefect.tasks.docker import PullImage
 from prefect.utilities.notifications import slack_notifier
 
 # Define current environment
-current_environment = "test"
+current_environment = "production"
 
 # Set up slack fail handler
 handler = slack_notifier(only_states=[Failed])
@@ -229,7 +229,7 @@ with Flow(
     storage=GitHub(
         repo="cityofaustin/atd-prefect",
         path="flows/parking/atd_parking_data_meters_txn_history.py",
-        ref="ch-parking-data-secrets",  # The branch name, staging is not being used here
+        ref="main",  # The branch name, staging is not being used here
     ),
     # Run config will always need the current_environment
     # plus whatever labels you need to attach to this flow

--- a/flows/parking/atd_parking_data_meters_txn_history.py
+++ b/flows/parking/atd_parking_data_meters_txn_history.py
@@ -103,7 +103,7 @@ def get_env_vars():
 @task(
     name="parking_transaction_history_to_s3",
     max_retries=1,
-    timeout=timedelta(minutes=60),
+    timeout=timedelta(minutes=180),
     retry_delay=timedelta(minutes=5),
     state_handlers=[handler],
     log_stdout=True,
@@ -131,7 +131,7 @@ def parking_transaction_history_to_s3(environment_variables):
 @task(
     name="parking_payment_history_to_s3",
     max_retries=1,
-    timeout=timedelta(minutes=60),
+    timeout=timedelta(minutes=180),
     retry_delay=timedelta(minutes=5),
     state_handlers=[handler],
     trigger=all_successful,
@@ -160,7 +160,7 @@ def parking_payment_history_to_s3(environment_variables):
 @task(
     name="pard_payment_history_to_s3",
     max_retries=1,
-    timeout=timedelta(minutes=60),
+    timeout=timedelta(minutes=180),
     retry_delay=timedelta(minutes=5),
     state_handlers=[handler],
     trigger=all_successful,
@@ -189,7 +189,7 @@ def pard_payment_history_to_s3(environment_variables):
 @task(
     name="app_txn_history_to_s3",
     max_retries=1,
-    timeout=timedelta(minutes=60),
+    timeout=timedelta(minutes=180),
     retry_delay=timedelta(minutes=5),
     state_handlers=[handler],
     trigger=all_successful,

--- a/flows/parking/parking_data_reconciliation.py
+++ b/flows/parking/parking_data_reconciliation.py
@@ -409,7 +409,7 @@ with Flow(
     storage=GitHub(
         repo="cityofaustin/atd-prefect",
         path="flows/parking/parking_data_reconciliation.py",
-        ref="production",  # The branch name
+        ref="ch-parking-data-secrets",  # The branch name
     ),
     # Run config will always need the current_environment
     # plus whatever labels you need to attach to this flow

--- a/flows/parking/parking_data_reconciliation.py
+++ b/flows/parking/parking_data_reconciliation.py
@@ -30,7 +30,7 @@ from prefect.tasks.docker import PullImage
 from prefect.utilities.notifications import slack_notifier
 
 # Define current environment
-current_environment = "test"
+current_environment = "production"
 
 # Set up slack fail handler
 handler = slack_notifier(only_states=[Failed])
@@ -409,7 +409,7 @@ with Flow(
     storage=GitHub(
         repo="cityofaustin/atd-prefect",
         path="flows/parking/parking_data_reconciliation.py",
-        ref="ch-parking-data-secrets",  # The branch name
+        ref="main",  # The branch name
     ),
     # Run config will always need the current_environment
     # plus whatever labels you need to attach to this flow

--- a/flows/parking/parking_data_reconciliation.py
+++ b/flows/parking/parking_data_reconciliation.py
@@ -30,7 +30,7 @@ from prefect.tasks.docker import PullImage
 from prefect.utilities.notifications import slack_notifier
 
 # Define current environment
-current_environment = "production"
+current_environment = "test"
 
 # Set up slack fail handler
 handler = slack_notifier(only_states=[Failed])
@@ -51,7 +51,7 @@ prev_execution_date_success = get_key_value(prev_execution_key)
 
 def decide_prev_month(prev_execution_date_success):
     """
-    Determines if the current month or the current plus previous month S3 
+    Determines if the current month or the current plus previous month S3
         folders are needed. If it is within a week of the previous month,
         also upsert that months data.
     Parameters
@@ -85,13 +85,24 @@ prev_month = decide_prev_month(prev_execution_date_success)
     timeout=timedelta(minutes=60),
     retry_delay=timedelta(minutes=5),
     state_handlers=[handler],
-    log_stdout=True
+    log_stdout=True,
 )
 def pull_docker_image():
     client = docker.from_env()
     client.images.pull("atddocker/atd-parking-data-meters", all_tags=True)
     logger.info(docker_env)
     return
+
+
+# Get the envrioment variables
+@task(
+    name="get_env_vars",
+    state_handlers=[handler],
+    log_stdout=True,
+)
+def get_env_vars():
+    environment_variables = get_key_value(key=f"atd_parking_data_meters")
+    return environment_variables
 
 
 # First, process the latest emails from Fiserv in S3
@@ -101,9 +112,9 @@ def pull_docker_image():
     timeout=timedelta(minutes=60),
     retry_delay=timedelta(minutes=5),
     state_handlers=[handler],
-    log_stdout=True
+    log_stdout=True,
 )
-def fiserv_email_parse():
+def fiserv_email_parse(environment_variables):
     response = (
         docker.from_env()
         .containers.run(
@@ -130,9 +141,9 @@ def fiserv_email_parse():
     retry_delay=timedelta(minutes=5),
     state_handlers=[handler],
     trigger=all_successful,
-    log_stdout=True
+    log_stdout=True,
 )
-def fiserv_emails_to_db():
+def fiserv_emails_to_db(environment_variables):
     response = (
         docker.from_env()
         .containers.run(
@@ -159,9 +170,9 @@ def fiserv_emails_to_db():
     retry_delay=timedelta(minutes=5),
     state_handlers=[handler],
     trigger=all_successful,
-    log_stdout=True
+    log_stdout=True,
 )
-def payment_csv_to_db():
+def payment_csv_to_db(environment_variables):
     response = (
         docker.from_env()
         .containers.run(
@@ -179,6 +190,7 @@ def payment_csv_to_db():
     logger.info(response)
     return response
 
+
 # Upload the PARD payment CSVs to postgres
 @task(
     name="pard_payment_csv_to_db",
@@ -187,9 +199,9 @@ def payment_csv_to_db():
     retry_delay=timedelta(minutes=5),
     state_handlers=[handler],
     trigger=all_successful,
-    log_stdout=True
+    log_stdout=True,
 )
-def pard_payment_csv_to_db():
+def pard_payment_csv_to_db(environment_variables):
     response = (
         docker.from_env()
         .containers.run(
@@ -216,9 +228,9 @@ def pard_payment_csv_to_db():
     retry_delay=timedelta(minutes=5),
     state_handlers=[handler],
     trigger=all_successful,
-    log_stdout=True
+    log_stdout=True,
 )
-def app_data_to_db():
+def app_data_to_db(environment_variables):
     response = (
         docker.from_env()
         .containers.run(
@@ -245,9 +257,9 @@ def app_data_to_db():
     retry_delay=timedelta(minutes=5),
     state_handlers=[handler],
     trigger=all_successful,
-    log_stdout=True
+    log_stdout=True,
 )
-def smartfolio_csv_to_db():
+def smartfolio_csv_to_db(environment_variables):
     response = (
         docker.from_env()
         .containers.run(
@@ -274,9 +286,9 @@ def smartfolio_csv_to_db():
     retry_delay=timedelta(minutes=5),
     state_handlers=[handler],
     trigger=all_successful,
-    log_stdout=True
+    log_stdout=True,
 )
-def matching_transactions():
+def matching_transactions(environment_variables):
     response = (
         docker.from_env()
         .containers.run(
@@ -303,9 +315,9 @@ def matching_transactions():
     retry_delay=timedelta(minutes=5),
     state_handlers=[handler],
     trigger=all_successful,
-    log_stdout=True
+    log_stdout=True,
 )
-def payments_to_socrata():
+def payments_to_socrata(environment_variables):
     response = (
         docker.from_env()
         .containers.run(
@@ -332,9 +344,9 @@ def payments_to_socrata():
     retry_delay=timedelta(minutes=5),
     state_handlers=[handler],
     trigger=all_successful,
-    log_stdout=True
+    log_stdout=True,
 )
-def fiserv_to_socrata():
+def fiserv_to_socrata(environment_variables):
     response = (
         docker.from_env()
         .containers.run(
@@ -361,9 +373,9 @@ def fiserv_to_socrata():
     retry_delay=timedelta(minutes=5),
     state_handlers=[handler],
     trigger=all_successful,
-    log_stdout=True
+    log_stdout=True,
 )
-def transactions_to_socrata():
+def transactions_to_socrata(environment_variables):
     response = (
         docker.from_env()
         .containers.run(
@@ -404,19 +416,20 @@ with Flow(
     run_config=UniversalRun(labels=[current_environment, "atd-data02"]),
     schedule=Schedule(clocks=[CronClock("00 5 * * *")]),
 ) as flow:
+    environment_variables = get_env_vars()
     flow.chain(
-        pull_docker_image,
-        fiserv_email_parse,
-        fiserv_emails_to_db,
-        payment_csv_to_db,
-        pard_payment_csv_to_db,
-        app_data_to_db,
-        matching_transactions,
-        smartfolio_csv_to_db,
-        payments_to_socrata,
-        fiserv_to_socrata,
-        transactions_to_socrata,
-        update_last_exec_time,
+        pull_docker_image(),
+        fiserv_email_parse(environment_variables),
+        fiserv_emails_to_db(environment_variables),
+        payment_csv_to_db(environment_variables),
+        pard_payment_csv_to_db(environment_variables),
+        app_data_to_db(environment_variables),
+        matching_transactions(environment_variables),
+        smartfolio_csv_to_db(environment_variables),
+        payments_to_socrata(environment_variables),
+        fiserv_to_socrata(environment_variables),
+        transactions_to_socrata(environment_variables),
+        update_last_exec_time(),
     )
 
 


### PR DESCRIPTION
After changing some secrets earlier this week, this flow was failing since I did not have a task to refresh our secrets each time we run this flow. This will also be needed for the ODP migration next Tuesday. Didn't realize that you can use `flow.chain` with arguments for your flows, makes your code much easier to read!

I also increased the timeout for some tasks that pull data from Flowbird since we had a significant backlog of data to download and they have a whooping one minute cooldown on API requests.

Note to self before merge:
- [x] change `current_envrionment` to `production`
- [x] change branch reference to `main`

After merge verify that the flow's schedule is turned on and `test` parking flow is turned off.