### PR TITLE
Add sequences to granted items for `staff` group in VZ DB permissions maintainer ETL

### DIFF
--- a/flows/vision-zero/db_permission_grantor/db_permission_grantor.py
+++ b/flows/vision-zero/db_permission_grantor/db_permission_grantor.py
@@ -55,6 +55,10 @@ def grant_permissions():
         sql = f'GRANT SELECT ON ALL TABLES IN SCHEMA {schema} TO staff'
         logger.info(sql)
         cursor.execute(sql)
+
+        sql = f'GRANT SELECT ON ALL SEQUENCES IN SCHEMA {schema} TO staff'
+        logger.info(sql)
+        cursor.execute(sql)
     
     pg.commit()
 


### PR DESCRIPTION
@chiaberry observed the following error from `pg_dump` when attempting to download the production database in the course of testing the VZ local development environment. 

```
pg_dump: error: query failed: ERROR:  permission denied for sequence recommendations_partners_id_seq
```

This PR adds a grant statement to the daily VZDB permission maintainer to ensure that the `staff` group has access to all sequences in the appropriate schemas.

If/when this makes it into `main`, I will merge it into `moped-project` and update our deployment.