### PR TITLE
Remediate CRIS import failure (branched from moped-project)

### DIFF
--- a/flows/vision-zero/cris_import/cris_import.py
+++ b/flows/vision-zero/cris_import/cris_import.py
@@ -225,7 +225,6 @@ def remove_archives_from_sftp_endpoint(zip_location):
 
 @task(name="pgloader CSV into DB", max_retries=2, retry_delay=datetime.timedelta(minutes=1))
 def pgloader_csvs_into_database(directory):
-    logger = prefect.context.get("logger")
     # Walk the directory and find all the CSV files
     pgloader_command_files_tmpdir = tempfile.mkdtemp()
     for root, dirs, files in os.walk(directory):
@@ -267,7 +266,7 @@ LOAD CSV
 $$;\n""")
                 cmd = f'pgloader {command_file}'
                 if os.system(cmd) != 0:
-                  logger.info('Unable to execute pgloader command')
+                  raise Exception("pgloader did not execute successfully")
 
     return pgloader_command_files_tmpdir
 

--- a/flows/vision-zero/cris_import/cris_import.py
+++ b/flows/vision-zero/cris_import/cris_import.py
@@ -244,13 +244,14 @@ def pgloader_csvs_into_database(directory):
                 command_file = pgloader_command_files_tmpdir + "/" + table + ".load"
                 print(f'Command file: {command_file}')
 
-                CONNECTION_STRING = f'postgresql://{DB_USER}:{DB_PASS}@{DB_HOST}:5432/{DB_NAME}'
+                # See https://github.com/dimitri/pgloader/issues/768#issuecomment-693390290
+                CONNECTION_STRING = f'postgresql://{DB_USER}:{DB_PASS}@{DB_HOST}:5432/{DB_NAME}?sslmode=allow'
 
                 with open(command_file, 'w') as file:
                     file.write(f"""
 LOAD CSV
     FROM '{directory}/{filename}' ({headers_line})
-    INTO  {CONNECTION_STRING}?import.{table} ({headers_line})
+    INTO  {CONNECTION_STRING}&import.{table} ({headers_line})
     WITH truncate,
         skip header = 1
     BEFORE LOAD DO 

--- a/flows/vision-zero/cris_import/cris_import.py
+++ b/flows/vision-zero/cris_import/cris_import.py
@@ -26,6 +26,8 @@ import prefect
 from prefect import task, Flow, Parameter
 from prefect.client import Client
 from prefect.backend import get_key_value
+from prefect.engine.state import Failed, TriggerFailed, Retrying
+from prefect.utilities.notifications import slack_notifier
 
 import lib.mappings as mappings
 import lib.sql as util
@@ -59,11 +61,15 @@ DB_PASS = kv_dictionary["DB_PASS"]
 DB_NAME = kv_dictionary["DB_NAME"]
 DB_IMPORT_SCHEMA = kv_dictionary["DB_IMPORT_SCHEMA"]
 
+# Set up slack fail handler
+handler = slack_notifier(only_states=[Failed, TriggerFailed, Retrying])
+
 @task(
     name="Specify where archive can be found",
     slug="locate-zips",
     max_retries=3,
     retry_delay=datetime.timedelta(minutes=2),
+    state_handlers=[handler],
 )
 def specify_extract_location(file):
     zip_tmpdir = tempfile.mkdtemp()
@@ -76,6 +82,7 @@ def specify_extract_location(file):
     slug="get-zips",
     max_retries=3,
     retry_delay=datetime.timedelta(minutes=2),
+    state_handlers=[handler],
 )
 def download_extract_archives():
     """
@@ -112,6 +119,7 @@ def download_extract_archives():
     max_retries=3,
     retry_delay=datetime.timedelta(minutes=2),
     nout=1,
+    state_handlers=[handler],
 )
 def unzip_archives(archives_directory):
     """
@@ -135,7 +143,7 @@ def unzip_archives(archives_directory):
     return extracted_csv_directories
 
 
-@task(name="Cleanup temporary directories", slug="cleanup-temporary-directories")
+@task(name="Cleanup temporary directories", slug="cleanup-temporary-directories", state_handlers=[handler],)
 def cleanup_temporary_directories(zip_location, pgloader_command_files, extracted_archives):
     """
     Remove directories that have accumulated during the flow's execution
@@ -165,7 +173,7 @@ def cleanup_temporary_directories(zip_location, pgloader_command_files, extracte
     return None
 
 
-@task(name="Upload CSV files on s3 for archival")
+@task(name="Upload CSV files on s3 for archival", state_handlers=[handler],)
 def upload_csv_files_to_s3(extract_directory):
     """
     Upload CSV files which came from CRIS exports up to S3 for archival
@@ -201,7 +209,7 @@ def upload_csv_files_to_s3(extract_directory):
     return extract_directory
 
 
-@task(name="Remove archive from SFTP Endpoint")
+@task(name="Remove archive from SFTP Endpoint", state_handlers=[handler],)
 def remove_archives_from_sftp_endpoint(zip_location):
     """
     Delete the archives which have been processed from the SFTP endpoint
@@ -223,7 +231,7 @@ def remove_archives_from_sftp_endpoint(zip_location):
 
     return None
 
-@task(name="pgloader CSV into DB", max_retries=2, retry_delay=datetime.timedelta(minutes=1))
+@task(name="pgloader CSV into DB", max_retries=2, retry_delay=datetime.timedelta(minutes=1), state_handlers=[handler],)
 def pgloader_csvs_into_database(directory):
     # Walk the directory and find all the CSV files
     pgloader_command_files_tmpdir = tempfile.mkdtemp()
@@ -271,7 +279,7 @@ $$;\n""")
     return pgloader_command_files_tmpdir
 
 
-@task(name="Remove trailing carriage returns from imported data")
+@task(name="Remove trailing carriage returns from imported data", state_handlers=[handler],)
 def remove_trailing_carriage_returns(data_loaded_token):
 
     pg = psycopg2.connect(host=DB_HOST, user=DB_USER, password=DB_PASS, dbname=DB_NAME, sslmode="require", sslrootcert="/root/rds-combined-ca-bundle.pem")
@@ -281,7 +289,7 @@ def remove_trailing_carriage_returns(data_loaded_token):
         util.trim_trailing_carriage_returns(pg, DB_IMPORT_SCHEMA, column)
 
 
-@task(name="Align DB Types")
+@task(name="Align DB Types", state_handlers=[handler],)
 def align_db_typing(trimmed_token):
 
     """
@@ -344,7 +352,7 @@ def align_db_typing(trimmed_token):
     return True
 
 
-@task(name="Insert / Update records in target schema")
+@task(name="Insert / Update records in target schema", state_handlers=[handler],)
 def align_records(typed_token, dry_run):
 
     """

--- a/flows/vision-zero/cris_import/cris_import.py
+++ b/flows/vision-zero/cris_import/cris_import.py
@@ -223,7 +223,7 @@ def remove_archives_from_sftp_endpoint(zip_location):
 
     return None
 
-@task(name="pgloader CSV into DB")
+@task(name="pgloader CSV into DB", max_retries=2, retry_delay=datetime.timedelta(minutes=1))
 def pgloader_csvs_into_database(directory):
     logger = prefect.context.get("logger")
     # Walk the directory and find all the CSV files

--- a/flows/vision-zero/cris_import/cris_import.py
+++ b/flows/vision-zero/cris_import/cris_import.py
@@ -225,6 +225,7 @@ def remove_archives_from_sftp_endpoint(zip_location):
 
 @task(name="pgloader CSV into DB")
 def pgloader_csvs_into_database(directory):
+    logger = prefect.context.get("logger")
     # Walk the directory and find all the CSV files
     pgloader_command_files_tmpdir = tempfile.mkdtemp()
     for root, dirs, files in os.walk(directory):
@@ -265,7 +266,8 @@ LOAD CSV
     );
 $$;\n""")
                 cmd = f'pgloader {command_file}'
-                os.system(cmd)
+                if os.system(cmd) != 0:
+                  logger.info('Unable to execute pgloader command')
 
     return pgloader_command_files_tmpdir
 


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/11402

This adds `sslmode` to the pgloader commands run by the CRIS import flow. Still kind of a mystery about why this worked prior to February 7 since the switch to `pgloader` was made before then and the flow ran successfully (possibly versioning?). I also added an exception that happens if the `pgloader` command fails and some retries to the task. Need some feedback on that since I'm not sure that will surface in the Prefect Cloud UI. 🙏 

I found https://github.com/dimitri/pgloader/issues/768#issuecomment-693390290 which led me to try `sslmode=allow` to get his back up and running. `require` is what we use with `psycopg2` but that errored out with `pgloader`. [Here are the PG docs about the SSL modes](https://www.postgresql.org/docs/current/libpq-ssl.html) but `allow` translates to "use SSL if it is there" as opposed to `require` which translates to "must use it." I've proved that our RDS will not accept non-SSL connections with both `psql` and trying `disable` mode with `pgloader`. I think that makes it safe to go ahead with this change.

Let me know if anyone disagrees or if there is something that I'm overlooking. Really enjoyed learning more on this one, and there is still so much more.

## Testing

Option 1:
YOLO - you trust that Frank and I have tested this enough. 🙏 

Option 2:
The best way that I can think of to test this is the test fixture that Frank and I used to test this. That file can be removed after this PR is approved. There is also a test extract that I placed on the SFTP server this morning (02/14/2023) for the test fixture to consume. If you run into any trouble with that, I can copy that test zip back into the `txdot` folder again.

1. SSH into `atd-data03`
2. `docker exec -it prefect-agent-vz bash` to attach to the VZ dockerized agent and start a bash shell
3. cd to `/root/cris_import` and then edit `cris_test_fixture.py` to revert the changes made in this PR
4. Save and then run `cris_test_fixture.py` - it should fail and log `KABOOM!` and then the DB connection errors as it maps through invocations of `pgloader_csvs_into_database()`
5. Change it back and see that there are no errors

**Ship list**
- [ ] Remove `cris_test_fixture.py` and `test_db_connection.py` from `/root/cris_import` in the dockerized agent
- [ ] Remove the test zip from the `txdot` folder on the SFTP server
- [ ] Code reviewed
- [ ] Product manager approved