### PR TITLE
Parking Data Task-Per-Command

### DIFF
--- a/deployments/parking_data_processing.yaml
+++ b/deployments/parking_data_processing.yaml
@@ -4,7 +4,7 @@
 name: 'atd-parking-data: Parking Data Processsing'
 description: 'Repo: https://github.com/cityofaustin/atd-parking-data Scripts that
   download and process parking data for finance reporting.'
-version: 9a46c085ce35eecb5fea75eadb0436ad
+version: c9dfaeac8455607b3e050ba2aa0150f6
 # The work queue that will handle this deployment's runs
 work_queue_name: default
 work_pool_name: atd-data-03
@@ -27,7 +27,7 @@ parameters:
   - parking_socrata.py --dataset payments
   - parking_socrata.py --dataset fiserv
   - parking_socrata.py --dataset transactions
-  docker_env: production
+  docker_env: latest
 schedule:
   cron: 35 8 * * *
   timezone: null
@@ -54,12 +54,12 @@ infrastructure:
   block_type_slug: process
   _block_type_slug: process
 storage:
-  repository: https://github.com/cityofaustin/atd-prefect/
-  reference: main
+  repository: https://github.com/cityofaustin/atd-prefect
+  reference: ch-parking-data-prefect2
   access_token: null
-  include_git_objects: false
-  _block_document_id: d0cc8e56-412b-49b3-bb9c-33b522c64736
-  _block_document_name: atd-prefect-main-branch
+  include_git_objects: true
+  _block_document_id: f0c06c99-55c4-41d1-a36c-8a09241aace7
+  _block_document_name: ch-parking-data-prefect2
   _is_anonymous: false
   block_type_slug: github
   _block_type_slug: github
@@ -87,4 +87,4 @@ parameter_openapi_schema:
   - s3_env
   - docker_env
   definitions: null
-timestamp: '2023-04-20T17:09:27.985238+00:00'
+timestamp: '2023-04-27T19:18:40.353450+00:00'

--- a/deployments/parking_data_processing.yaml
+++ b/deployments/parking_data_processing.yaml
@@ -54,12 +54,12 @@ infrastructure:
   block_type_slug: process
   _block_type_slug: process
 storage:
-  repository: https://github.com/cityofaustin/atd-prefect
-  reference: ch-parking-data-prefect2
+  repository: https://github.com/cityofaustin/atd-prefect/
+  reference: main
   access_token: null
-  include_git_objects: true
-  _block_document_id: f0c06c99-55c4-41d1-a36c-8a09241aace7
-  _block_document_name: ch-parking-data-prefect2
+  include_git_objects: false
+  _block_document_id: d0cc8e56-412b-49b3-bb9c-33b522c64736
+  _block_document_name: atd-prefect-main-branch
   _is_anonymous: false
   block_type_slug: github
   _block_type_slug: github
@@ -87,4 +87,4 @@ parameter_openapi_schema:
   - s3_env
   - docker_env
   definitions: null
-timestamp: '2023-04-27T19:18:40.353450+00:00'
+timestamp: '2023-05-01T22:54:03.674109+00:00'


### PR DESCRIPTION
Was getting some errors from our parking data ETL and whenever it ran into an issue it would restart the whole ETL. This change moves the for loop outside the task so now each docker command is run with it's own retry settings.