### PR TITLE
Trail counter data publishing to Prefect 2

### DIFF
--- a/deployments/ped_data_pub.yaml
+++ b/deployments/ped_data_pub.yaml
@@ -1,0 +1,64 @@
+###
+### A complete description of a Prefect Deployment for flow 'atd-parking-data: Parking Data Processsing'
+###
+name: 'atd-trail-counter-data: Trail Counter Data Publishing'
+description: 'Repo: https://github.com/cityofaustin/atd-trail-counter-data wrapper
+  for ETL that     scrapes trail counter data from the public eco-counter website
+  and publishes it in Socrata.'
+version: 84e9cd582f1140d660d7547de65ec68c
+# The work queue that will handle this deployment's runs
+work_queue_name: default
+work_pool_name: atd-data-03
+tags: []
+parameters: 
+  block: ped-data-pub
+  docker_env: latest 
+schedule:
+  cron: 00 8 * * *
+  timezone: null
+  day_or: true
+is_schedule_active: null
+infra_overrides: {}
+infrastructure:
+  type: process
+  env: {}
+  labels: {}
+  name: null
+  command: null
+  stream_output: true
+  working_dir: null
+  block_type_slug: process
+  _block_type_slug: process
+
+###
+### DO NOT EDIT BELOW THIS LINE
+###
+flow_name: 'atd-parking-data: Parking Data Processsing'
+manifest_path: null
+storage:
+  repository: github.com/cityofaustin/atd-prefect/
+  reference: ch-ped-counters
+  access_token: null
+  include_git_objects: true
+  _block_document_id: a6aa4517-bb5b-4a07-a4df-6e2b034081bc
+  _block_document_name: ch-ped-counters
+  _is_anonymous: false
+  block_type_slug: github
+  _block_type_slug: github
+path: ''
+entrypoint: flows/atd-trail-counter-data/ped_data_pub.py:main
+parameter_openapi_schema:
+  title: Parameters
+  type: object
+  properties:
+    block:
+      title: block
+      position: 0
+    docker_env:
+      title: docker_env
+      position: 1
+  required:
+  - block
+  - docker_env
+  definitions: null
+timestamp: '2023-04-28T15:52:12.709910+00:00'

--- a/deployments/ped_data_pub.yaml
+++ b/deployments/ped_data_pub.yaml
@@ -5,20 +5,26 @@ name: 'atd-trail-counter-data: Trail Counter Data Publishing'
 description: 'Repo: https://github.com/cityofaustin/atd-trail-counter-data wrapper
   for ETL that     scrapes trail counter data from the public eco-counter website
   and publishes it in Socrata.'
-version: 7eb3255978acc6d919f835f4295485da
+version: 8b5282ee64ac47cd818af4023320009a
 # The work queue that will handle this deployment's runs
 work_queue_name: default
 work_pool_name: atd-data-03
 tags: []
-parameters: 
+parameters:
   block: ped-data-pub
   docker_env: latest
 schedule:
   cron: 00 8 * * *
   timezone: null
   day_or: true
-is_schedule_active: null
+is_schedule_active: true
 infra_overrides: {}
+
+###
+### DO NOT EDIT BELOW THIS LINE
+###
+flow_name: 'atd-trail-counter-data: Trail Counter Data Publishing'
+manifest_path: null
 infrastructure:
   type: process
   env: {}
@@ -27,21 +33,18 @@ infrastructure:
   command: null
   stream_output: true
   working_dir: null
+  _block_document_id: 7302357b-47c8-4d2c-9d20-75ecdd43858b
+  _block_document_name: anonymous-e68da45d-b781-470f-95c9-0e58319dbd2a
+  _is_anonymous: true
   block_type_slug: process
   _block_type_slug: process
-
-###
-### DO NOT EDIT BELOW THIS LINE
-###
-flow_name: 'atd-trail-counter-data: Trail Counter Data Publishing'
-manifest_path: null
 storage:
-  repository: github.com/cityofaustin/atd-prefect/
-  reference: ch-ped-counters
+  repository: https://github.com/cityofaustin/atd-prefect/
+  reference: main
   access_token: null
-  include_git_objects: true
-  _block_document_id: a6aa4517-bb5b-4a07-a4df-6e2b034081bc
-  _block_document_name: ch-ped-counters
+  include_git_objects: false
+  _block_document_id: d0cc8e56-412b-49b3-bb9c-33b522c64736
+  _block_document_name: atd-prefect-main-branch
   _is_anonymous: false
   block_type_slug: github
   _block_type_slug: github
@@ -61,4 +64,4 @@ parameter_openapi_schema:
   - block
   - docker_env
   definitions: null
-timestamp: '2023-04-28T15:55:25.611348+00:00'
+timestamp: '2023-05-02T15:05:08.120979+00:00'

--- a/deployments/ped_data_pub.yaml
+++ b/deployments/ped_data_pub.yaml
@@ -1,18 +1,18 @@
 ###
-### A complete description of a Prefect Deployment for flow 'atd-parking-data: Parking Data Processsing'
+### A complete description of a Prefect Deployment for flow 'atd-trail-counter-data: Trail Counter Data Publishing'
 ###
 name: 'atd-trail-counter-data: Trail Counter Data Publishing'
 description: 'Repo: https://github.com/cityofaustin/atd-trail-counter-data wrapper
   for ETL that     scrapes trail counter data from the public eco-counter website
   and publishes it in Socrata.'
-version: 84e9cd582f1140d660d7547de65ec68c
+version: 7eb3255978acc6d919f835f4295485da
 # The work queue that will handle this deployment's runs
 work_queue_name: default
 work_pool_name: atd-data-03
 tags: []
 parameters: 
   block: ped-data-pub
-  docker_env: latest 
+  docker_env: latest
 schedule:
   cron: 00 8 * * *
   timezone: null
@@ -33,7 +33,7 @@ infrastructure:
 ###
 ### DO NOT EDIT BELOW THIS LINE
 ###
-flow_name: 'atd-parking-data: Parking Data Processsing'
+flow_name: 'atd-trail-counter-data: Trail Counter Data Publishing'
 manifest_path: null
 storage:
   repository: github.com/cityofaustin/atd-prefect/
@@ -61,4 +61,4 @@ parameter_openapi_schema:
   - block
   - docker_env
   definitions: null
-timestamp: '2023-04-28T15:52:12.709910+00:00'
+timestamp: '2023-04-28T15:55:25.611348+00:00'

--- a/flows/atd-trail-counter-data/ped_data_pub.py
+++ b/flows/atd-trail-counter-data/ped_data_pub.py
@@ -113,7 +113,7 @@ def update_exec_date(json_block):
     block.save(name=json_block, overwrite=True)
 
 
-@flow(name="atd-parking-data: Parking Data Processsing")
+@flow(name="atd-trail-counter-data: Trail Counter Data Publishing")
 def main(block, docker_env):
     # Logger instance
     logger = get_run_logger()

--- a/flows/atd-trail-counter-data/ped_data_pub.py
+++ b/flows/atd-trail-counter-data/ped_data_pub.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python
+
+"""
+Name: atd-trail-counter-data: Trail Counter Data Publishing
+Description: Repo: https://github.com/cityofaustin/atd-trail-counter-data wrapper for ETL that
+    scrapes trail counter data from the public eco-counter website and publishes it in Socrata.
+
+Create Deployment:
+$ prefect deployment build flows/atd-trail-counter-data/ped_data_pub.py:main \
+    --name "atd-trail-counter-data: Trail Counter Data Publishing" \
+    --pool atd-data-03 \
+    --cron "00 8 * * *" \
+    -q default \
+    -sb github/ch-ped-counters \
+    -o "deployments/ped_data_pub.yaml"\
+    --skip-upload \
+    --description "Repo: https://github.com/cityofaustin/atd-trail-counter-data wrapper for ETL that \
+    scrapes trail counter data from the public eco-counter website and publishes it in Socrata."
+ 
+$ prefect deployment apply deployments/ped_data_pub.yaml
+"""
+
+import os
+
+import docker
+import prefect
+from datetime import datetime, timedelta
+
+# Prefect
+from prefect import flow, task, get_run_logger
+from prefect.blocks.system import JSON
+
+
+# Docker settings
+docker_image = "atddocker/atd-trail-counters"
+
+
+@task(
+    name="get_env_vars",
+    retries=10,
+    retry_delay_seconds=timedelta(seconds=15).seconds,
+)
+def get_env_vars(json_block):
+    # Environment Variables stored in JSON block in Prefect
+    return JSON.load(json_block).dict()["value"]
+
+
+@task(
+    name="pull_docker_image",
+    retries=1,
+    retry_delay_seconds=timedelta(minutes=5).seconds,
+)
+def pull_docker_image(docker_env):
+    client = docker.from_env()
+    client.images.pull(docker_image, tag=docker_env)
+    return True
+
+
+@task
+def get_start_date(prev_execution_date_success):
+    """Creates a start date 7 days before the date of the last successful run of the flow
+
+    Args:
+        prev_execution_date_success (string): Date of the last successful run of the flow
+
+    Returns:
+        list: The start date (string) which is 7 days before the last run.
+        Defaults to 2014-01-01 if none were previously successful.
+    """
+    if prev_execution_date_success:
+        # parse CLI arg date
+        start_date = datetime.strptime(prev_execution_date_success, "%Y-%m-%d")
+        start_date = start_date - timedelta(days=7)
+
+        return start_date.strftime("%Y-%m-%d")
+    else:
+        return "2014-01-01"
+
+
+@task(
+    name="trail_counter_data_publish",
+    retries=3,
+    retry_delay_seconds=timedelta(minutes=2).seconds,
+)
+def trail_counter_data_publish(docker_env, environment_variables, start_date, logger):
+    response = (
+        docker.from_env()
+        .containers.run(
+            image=f"{docker_image}:{docker_env}",
+            working_dir=None,
+            command=f"python counter_data.py --start {start_date}",
+            environment=environment_variables,
+            volumes=None,
+            remove=True,
+            detach=False,
+            stdout=True,
+        )
+        .decode("utf-8")
+    )
+    logger.info(response)
+    return response
+
+
+@task(
+    name="update_exec_date",
+    retries=10,
+    retry_delay_seconds=15,
+)
+def update_exec_date(json_block):
+    # Update our JSON block with the updated date of last flow execution
+    block = JSON.load(json_block)
+    block.value["PREV_EXEC"] = datetime.today().strftime("%Y-%m-%d")
+    block.save(name=json_block, overwrite=True)
+
+
+@flow(name="atd-parking-data: Parking Data Processsing")
+def main(commands, block, s3_env, docker_env):
+    # Logger instance
+    logger = get_run_logger()
+
+    # Start: get env vars and pull the latest docker image
+    environment_variables = get_env_vars(block)
+    docker_res = pull_docker_image(docker_env)
+
+    # Get previous exec date
+    start_date = get_start_date(environment_variables["PREV_EXEC"])
+
+    # Run our commands
+    if docker_res:
+        commands_res = trail_counter_data_publish(
+            docker_env, environment_variables, start_date, logger
+        )
+    if commands_res:
+        update_exec_date(block)
+
+
+if __name__ == "__main__":
+    # Environment Variable Storage Block Name
+    block = "ped-data-pub"
+
+    # Tag of docker image to use
+    docker_env = "latest"
+
+    main(commands, block, s3_env, docker_env)

--- a/flows/atd-trail-counter-data/ped_data_pub.py
+++ b/flows/atd-trail-counter-data/ped_data_pub.py
@@ -11,7 +11,7 @@ $ prefect deployment build flows/atd-trail-counter-data/ped_data_pub.py:main \
     --pool atd-data-03 \
     --cron "00 8 * * *" \
     -q default \
-    -sb github/ch-ped-counters \
+    -sb github/atd-prefect-main-branch \
     -o "deployments/ped_data_pub.yaml"\
     --skip-upload \
     --description "Repo: https://github.com/cityofaustin/atd-trail-counter-data wrapper for ETL that \

--- a/flows/atd-trail-counter-data/ped_data_pub.py
+++ b/flows/atd-trail-counter-data/ped_data_pub.py
@@ -114,7 +114,7 @@ def update_exec_date(json_block):
 
 
 @flow(name="atd-parking-data: Parking Data Processsing")
-def main(commands, block, s3_env, docker_env):
+def main(block, docker_env):
     # Logger instance
     logger = get_run_logger()
 
@@ -141,4 +141,4 @@ if __name__ == "__main__":
     # Tag of docker image to use
     docker_env = "latest"
 
-    main(commands, block, s3_env, docker_env)
+    main(block, docker_env)


### PR DESCRIPTION
A little [ETL I wrote](https://github.com/cityofaustin/atd-trail-counter-data/tree/main) to scrape data from the [eco counter website](https://data.eco-counter.com/ParcPublic/?id=89#) and then publish the data in [private socrata dataset](https://datahub.austintexas.gov/Transportation-and-Mobility/Trail-Counters-Daily-Totals/26tt-cp67).

I guess I never PR'd me setting this up in Prefect 1.0. 