### PR TITLE
Quarterly Bond Reporting Orchestration

### DIFF
--- a/deployments/atd-bond-reporting.yaml
+++ b/deployments/atd-bond-reporting.yaml
@@ -5,7 +5,7 @@ name: Bond Reporting Data Scripts
 description: 'Repo: https://github.com/cityofaustin/atd-bond-reporting Wrapper ETL
   for the atd-bond-reporting docker image with commands for moving the data from S3
   to Socrata.'
-version: 25b0d610bfb9d3a2ee0c2a6978125324
+version: 23006097688188a325f41d89432f96a7
 # The work queue that will handle this deployment's runs
 work_queue_name: default
 work_pool_name: atd-data-03
@@ -15,15 +15,12 @@ parameters:
   commands:
   - atd-bond-reporting/microstrategy_to_s3.py -r "2020 Bond Expenses Obligated"
   - atd-bond-reporting/microstrategy_to_s3.py -r "All bonds Expenses Obligated"
-  - atd-bond-reporting/microstrategy_to_s3.py -r "2020 FDUs with Subproject and Appropriation"
-  - atd-bond-reporting/microstrategy_to_s3.py -r "Subprojects with total Appropriation"
-  - atd-bond-reporting/microstrategy_to_s3.py -r "Open Subprojects with Budget Estimate"
   - atd-bond-reporting/microstrategy_to_s3.py -r "FDU Expenses by Quarter"
   - atd-bond-reporting/microstrategy_to_s3.py -r "2020 Division Group and Unit"
   - atd-bond-reporting/bond_data.py
   - atd-bond-reporting/bond_calculations.py
   - atd-bond-reporting/quarterly_reporting.py
-  docker_tag: latest
+  docker_tag: production
 schedule:
   cron: 0 15 * * *
   timezone: null
@@ -51,11 +48,11 @@ infrastructure:
   _block_type_slug: process
 storage:
   repository: https://github.com/cityofaustin/atd-prefect/
-  reference: ch-bond-reporting
-  access_token: null
-  include_git_objects: true
-  _block_document_id: 1a001b10-7b11-4526-8f78-7fc58b1b5354
-  _block_document_name: ch-bond-reporting
+  reference: main
+  access_token: '**********'
+  include_git_objects: false
+  _block_document_id: d0cc8e56-412b-49b3-bb9c-33b522c64736
+  _block_document_name: atd-prefect-main-branch
   _is_anonymous: false
   block_type_slug: github
   _block_type_slug: github
@@ -79,4 +76,4 @@ parameter_openapi_schema:
   - block
   - docker_tag
   definitions: null
-timestamp: '2023-05-11T16:25:30.833801+00:00'
+timestamp: '2023-06-15T15:52:26.692445+00:00'

--- a/deployments/atd-bond-reporting.yaml
+++ b/deployments/atd-bond-reporting.yaml
@@ -5,7 +5,7 @@ name: Bond Reporting Data Scripts
 description: 'Repo: https://github.com/cityofaustin/atd-bond-reporting Wrapper ETL
   for the atd-bond-reporting docker image with commands for moving the data from S3
   to Socrata.'
-version: 19d786fc4a4a9a5f97dd149e94f05f0d
+version: 25b0d610bfb9d3a2ee0c2a6978125324
 # The work queue that will handle this deployment's runs
 work_queue_name: default
 work_pool_name: atd-data-03
@@ -17,6 +17,7 @@ parameters:
   - atd-bond-reporting/microstrategy_to_s3.py -r "All bonds Expenses Obligated"
   - atd-bond-reporting/bond_data.py
   - atd-bond-reporting/bond_calculations.py
+  docker_tag: latest
 schedule:
   cron: 0 15 * * *
   timezone: null
@@ -44,11 +45,11 @@ infrastructure:
   _block_type_slug: process
 storage:
   repository: https://github.com/cityofaustin/atd-prefect/
-  reference: main
+  reference: ch-bond-reporting
   access_token: null
-  include_git_objects: false
-  _block_document_id: d0cc8e56-412b-49b3-bb9c-33b522c64736
-  _block_document_name: atd-prefect-main-branch
+  include_git_objects: true
+  _block_document_id: 1a001b10-7b11-4526-8f78-7fc58b1b5354
+  _block_document_name: ch-bond-reporting
   _is_anonymous: false
   block_type_slug: github
   _block_type_slug: github
@@ -64,8 +65,12 @@ parameter_openapi_schema:
     block:
       title: block
       position: 1
+    docker_tag:
+      title: docker_tag
+      position: 2
   required:
   - commands
   - block
+  - docker_tag
   definitions: null
-timestamp: '2023-04-03T16:45:39.288332+00:00'
+timestamp: '2023-05-11T16:25:30.833801+00:00'

--- a/deployments/atd-bond-reporting.yaml
+++ b/deployments/atd-bond-reporting.yaml
@@ -15,8 +15,14 @@ parameters:
   commands:
   - atd-bond-reporting/microstrategy_to_s3.py -r "2020 Bond Expenses Obligated"
   - atd-bond-reporting/microstrategy_to_s3.py -r "All bonds Expenses Obligated"
+  - atd-bond-reporting/microstrategy_to_s3.py -r "2020 FDUs with Subproject and Appropriation"
+  - atd-bond-reporting/microstrategy_to_s3.py -r "Subprojects with total Appropriation"
+  - atd-bond-reporting/microstrategy_to_s3.py -r "Open Subprojects with Budget Estimate"
+  - atd-bond-reporting/microstrategy_to_s3.py -r "FDU Expenses by Quarter"
+  - atd-bond-reporting/microstrategy_to_s3.py -r "2020 Division Group and Unit"
   - atd-bond-reporting/bond_data.py
   - atd-bond-reporting/bond_calculations.py
+  - atd-bond-reporting/quarterly_reporting.py
   docker_tag: latest
 schedule:
   cron: 0 15 * * *

--- a/flows/atd-bond-reporting/atd-bond-reporting.py
+++ b/flows/atd-bond-reporting/atd-bond-reporting.py
@@ -59,24 +59,24 @@ def pull_docker_image(docker_env):
     name="docker_commands",
     retries=3,
     retry_delay_seconds=timedelta(minutes=2).seconds,
+    task_run_name="Docker Command: {command}",
 )
-def docker_commands(environment_variables, commands, logger, docker_env):
-    for c in commands:
-        response = (
-            docker.from_env()
-            .containers.run(
-                image=f"{docker_image}:{docker_env}",
-                working_dir=None,
-                command=f"python {c}",
-                environment=environment_variables,
-                volumes=None,
-                remove=True,
-                detach=False,
-                stdout=True,
-            )
-            .decode("utf-8")
+def docker_commands(environment_variables, command, logger, docker_env):
+    response = (
+        docker.from_env()
+        .containers.run(
+            image=f"{docker_image}:{docker_env}",
+            working_dir=None,
+            command=f"python {command}",
+            environment=environment_variables,
+            volumes=None,
+            remove=True,
+            detach=False,
+            stdout=True,
         )
-        logger.info(response)
+        .decode("utf-8")
+    )
+    logger.info(response)
     return response
 
 
@@ -102,10 +102,8 @@ def main(commands, block, docker_tag):
     docker_res = pull_docker_image(docker_tag)
 
     # Run our commands
-    if docker_res:
-        commands_res = docker_commands(
-            environment_variables, commands, logger, docker_tag
-        )
+    for c in commands:
+        commands_res = docker_commands(environment_variables, c, logger, docker_tag)
     if commands_res:
         update_exec_date(block)
 
@@ -116,8 +114,14 @@ if __name__ == "__main__":
     commands = [
         'atd-bond-reporting/microstrategy_to_s3.py -r "2020 Bond Expenses Obligated"',
         'atd-bond-reporting/microstrategy_to_s3.py -r "All bonds Expenses Obligated"',
+        'atd-bond-reporting/microstrategy_to_s3.py -r "2020 FDUs with Subproject and Appropriation"',
+        'atd-bond-reporting/microstrategy_to_s3.py -r "Subprojects with total Appropriation"',
+        'atd-bond-reporting/microstrategy_to_s3.py -r "Open Subprojects with Budget Estimate"',
+        'atd-bond-reporting/microstrategy_to_s3.py -r "FDU Expenses by Quarter"',
+        'atd-bond-reporting/microstrategy_to_s3.py -r "2020 Division Group and Unit"',
         "atd-bond-reporting/bond_data.py",
         "atd-bond-reporting/bond_calculations.py",
+        "atd-bond-reporting/quarterly_reporting.py",
     ]
 
     # Environment Variable Storage Block Name

--- a/flows/atd-bond-reporting/atd-bond-reporting.py
+++ b/flows/atd-bond-reporting/atd-bond-reporting.py
@@ -11,7 +11,7 @@ $ prefect deployment build flows/atd-bond-reporting/atd-bond-reporting.py:main \
     --pool atd-data-03 \
     --cron "0 15 * * *" \
     -q default \
-    -sb github/ch-bond-reporting \
+    -sb github/atd-prefect-main-branch \
     -o "deployments/atd-bond-reporting.yaml"\
     --skip-upload \
     --description "Repo: https://github.com/cityofaustin/atd-bond-reporting Wrapper ETL for the atd-bond-reporting docker image with commands for moving the data from S3 to Socrata."
@@ -114,9 +114,6 @@ if __name__ == "__main__":
     commands = [
         'atd-bond-reporting/microstrategy_to_s3.py -r "2020 Bond Expenses Obligated"',
         'atd-bond-reporting/microstrategy_to_s3.py -r "All bonds Expenses Obligated"',
-        'atd-bond-reporting/microstrategy_to_s3.py -r "2020 FDUs with Subproject and Appropriation"',
-        'atd-bond-reporting/microstrategy_to_s3.py -r "Subprojects with total Appropriation"',
-        'atd-bond-reporting/microstrategy_to_s3.py -r "Open Subprojects with Budget Estimate"',
         'atd-bond-reporting/microstrategy_to_s3.py -r "FDU Expenses by Quarter"',
         'atd-bond-reporting/microstrategy_to_s3.py -r "2020 Division Group and Unit"',
         "atd-bond-reporting/bond_data.py",
@@ -128,6 +125,6 @@ if __name__ == "__main__":
     block = "atd-bond-reporting"
 
     # Docker tag
-    docker_tag = "latest"
+    docker_tag = "production"
 
     main(commands, block, docker_tag)


### PR DESCRIPTION
Modifies the current bond reporting flow:
- adds docker tag parameter so we can test changes to the ETL easily
- adds commands for quarterly reporting (WIP)
- changed to task-per-command

[Currently running here](https://app.prefect.cloud/account/62be21ad-87d4-4858-bc47-a49e1fd29df7/workspace/4e909dab-3495-4e26-9403-9b633af2c970/deployments/deployment/dcc11d57-4cb5-46e4-b8b3-1af85e92f275)
